### PR TITLE
refactor: 멤버id를 헤더에서 찾도록 수정

### DIFF
--- a/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/application/SubscriptionService.java
+++ b/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/application/SubscriptionService.java
@@ -42,11 +42,11 @@ public class SubscriptionService {
     }
 
     @Transactional
-    public SubscriptionInfo create(SubscriptionCreateCommand command) {
+    public SubscriptionInfo create(SubscriptionCreateCommand command, UUID memberId) {
         ProductInfoResponse productInfo = getProductInfo(command.productId());
 
         Subscription subscription = Subscription.create(
-                command.memberId(),
+                memberId,
                 productInfo.id(),
                 productInfo.name(),
                 productInfo.thumbnailUrl(),

--- a/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/application/dto/SubscriptionCreateCommand.java
+++ b/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/application/dto/SubscriptionCreateCommand.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record SubscriptionCreateCommand(
-        UUID memberId,  // TODO: 회원ID를 내부에서 확인하도록 수정
         UUID productId,
         Integer quantity,
         String deliveryAddress,

--- a/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/domain/Subscription.java
+++ b/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/domain/Subscription.java
@@ -19,7 +19,7 @@ import static com.node5.subscriptionservice.subscription.exception.SubscriptionE
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "\"subscription\"", schema = "public")
+@Table(name = "\"subscription\"", schema = "subscription")
 public class Subscription extends BaseEntity {
 
     @Id

--- a/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/presentation/SubscriptionController.java
+++ b/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/presentation/SubscriptionController.java
@@ -30,17 +30,16 @@ public class SubscriptionController {
         return ResponseEntity.ok(subscriptionService.findById(id));
     }
 
-    // TODO: 회원ID를 내부에서 확인하도록 수정
     @Operation(summary = "구독 전체 조회", description = "회원의 전체 구독 리스트를 조회합니다.")
     @GetMapping
-    public ResponseEntity<Page<SubscriptionInfo>> findAllByMemberId(@RequestParam UUID memberId, Pageable pageable) {
+    public ResponseEntity<Page<SubscriptionInfo>> findAllByMemberId(@RequestHeader("Member-Id") UUID memberId, Pageable pageable) {
         return ResponseEntity.ok(subscriptionService.findAllByMemberId(memberId, pageable));
     }
 
     @Operation(summary = "구독 생성", description = "새로운 구독을 생성합니다")
     @PostMapping
-    public ResponseEntity<SubscriptionInfo> create(@RequestBody @Valid SubscriptionCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(subscriptionService.create(request.toCommand()));
+    public ResponseEntity<SubscriptionInfo> create(@RequestBody @Valid SubscriptionCreateRequest request, @RequestHeader("Member-Id") UUID memberId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(subscriptionService.create(request.toCommand(), memberId));
     }
 
     @Operation(summary = "구독 수정", description = "구독 정보를 수정합니다.")

--- a/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/presentation/dto/SubscriptionCreateRequest.java
+++ b/subscription-service/src/main/java/com/node5/subscriptionservice/subscription/presentation/dto/SubscriptionCreateRequest.java
@@ -9,9 +9,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record SubscriptionCreateRequest(
-        @NotNull(message = "회원 ID는 필수 입력값입니다.")
-        UUID memberId,  // TODO: 회원ID를 내부에서 확인하도록 수정
-
         @NotNull(message = "상품 ID는 필수 입력값입니다.")
         UUID productId,
 
@@ -67,7 +64,6 @@ public record SubscriptionCreateRequest(
         }
 
         return new SubscriptionCreateCommand(
-                memberId,
                 productId,
                 quantity,
                 deliveryAddress,


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #89 

## 📌 개요
- 기존에 dto로 memberId를 받던 것을 헤더에서 찾도록 수정했습니다.

## ✨ 작업 내용
- 컨트롤러에 @RequestHeader 사용
- dto에서 memberId 제거
- 구독 엔티티 스키마 'subscription'으로 설정

## 🧪 테스트 방법
- 빌드, 스웨거 실행

## 🔗 참고 사항 : 
- 스크린샷, 참고 문서 등

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [x] 오류가 발생하지 않습니다.
- [x] 테스트를 전부 통과했습니다.
- [x] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [x] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [x] 이슈 번호를 입력 했습니다.
- [x] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
