### PR TITLE
fix: 예치금 정산 API 호출 시 필요한 헤더 요청값 추가

### DIFF
--- a/config/config/order-service.yaml
+++ b/config/config/order-service.yaml
@@ -18,6 +18,10 @@ spring:
   sql:
     init:
       mode: always #SQL 초기화 파일(schema.sql) 항상 실행
+  task:
+    scheduling:
+      cron:
+        collect-settlement-source: ${SCHEDULER_CRON_COLLECT_SETTLEMENT_SOURCE}
 
 api:
   v1: /api/v1

--- a/order-service/src/main/java/com/node5/orderservice/order/application/OrderScheduler.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/application/OrderScheduler.java
@@ -19,7 +19,7 @@ public class OrderScheduler {
     public void updateOrderStatus() {
         log.info("** Order status update scheduler started at {}", LocalDateTime.now());
 
-        LocalDateTime ago = LocalDateTime.now().minusMinutes(1); //TODO 테스트용 설정
+        LocalDateTime ago = LocalDateTime.now().minusMinutes(1);
 
         // PAID -> DELIVERY_ING 갱신
         orderTransactionService.updateToDeliveryIng(ago);
@@ -34,8 +34,7 @@ public class OrderScheduler {
     }
 
     // 매일 CONFIRMED 상태의 주문만 조회하여 정산 API를 호출
-    //@Scheduled(cron = "0 0 0 * * *")
-    @Scheduled(cron = "0 */3 * * * *") //테스트: 3분
+    @Scheduled(cron = "${scheduling.cron.collect-settlement-source:0 */5 * * * *}")
     public void processSettlementRequest(){
         orderTransactionService.processSettlementRequest();
     }

--- a/settlement-service/src/main/java/com/node5/settlementservice/config/OpenFeignConfig.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/config/OpenFeignConfig.java
@@ -2,13 +2,14 @@ package com.node5.settlementservice.config;
 
 import com.node5.settlementservice.settlement.client.BillingClient;
 import com.node5.settlementservice.settlement.client.BillingErrorDecoder;
+import com.node5.settlementservice.settlement.client.ShopClient;
 import feign.codec.ErrorDecoder;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableFeignClients(clients = BillingClient.class)
+@EnableFeignClients(clients = {BillingClient.class, ShopClient.class})
 public class OpenFeignConfig {
 
     @Bean

--- a/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementBatchConfig.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementBatchConfig.java
@@ -1,6 +1,7 @@
 package com.node5.settlementservice.settlement.batch;
 
 import com.node5.settlementservice.settlement.client.BillingClient;
+import com.node5.settlementservice.settlement.client.ShopClient;
 import com.node5.settlementservice.settlement.client.dto.WalletInfo;
 import com.node5.settlementservice.settlement.client.dto.WalletSettleRequest;
 import com.node5.settlementservice.settlement.domain.*;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 public class SettlementBatchConfig {
     private static final BigDecimal FEE_RATE = new BigDecimal("0.05"); // 수수료율 5% 고정
     private final BillingClient billingClient;
+    private final ShopClient shopClient;
 
     // Job: 전체 정산 작업 정의
     @Bean
@@ -132,9 +134,14 @@ public class SettlementBatchConfig {
                         try {
                             // 에치금 정산 API 요청
                             BigDecimal roundedAmount = result.getPayoutAmount().setScale(0, RoundingMode.HALF_UP);
-                            ResponseEntity<WalletInfo> response = billingClient.settle(new WalletSettleRequest(result.getId(), roundedAmount.longValue()));
+                            ResponseEntity<String> shopResponse = shopClient.getMemberIdByShopId(UUID.fromString(shopParam));
+                            String memberId = null;
+                            if(shopResponse.getStatusCode().is2xxSuccessful()){
+                                memberId = shopResponse.getBody();
+                            }
+                            ResponseEntity<WalletInfo> walletResponse = billingClient.settle(UUID.fromString(memberId), new WalletSettleRequest(result.getId(), roundedAmount.longValue()));
 
-                            if (response.getStatusCode().is2xxSuccessful()) {
+                            if (walletResponse.getStatusCode().is2xxSuccessful()) {
                                 result.markPaid();
                             }
                         } catch(FeignException e) {

--- a/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementScheduler.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementScheduler.java
@@ -32,7 +32,7 @@ public class SettlementScheduler {
     private boolean settlementAsyncEnabled;
     private final SettlementSourceRepository settlementSourceRepository;
 
-    @Scheduled(cron = "${spring.task.scheduling.cron.settlement:0 */3 * * * *}") // 테스트: 3분
+    @Scheduled(cron = "${spring.task.scheduling.cron.settlement:0 */10 * * * *}")
     public void runMonthlySettlement() {
         YearMonth previousMonth = YearMonth.now().minusMonths(1);
 

--- a/settlement-service/src/main/java/com/node5/settlementservice/settlement/client/BillingClient.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/settlement/client/BillingClient.java
@@ -7,11 +7,17 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
 
 @FeignClient(name = "billing-service")
 public interface BillingClient {
 
     @PutMapping("/internal/wallets/settle")
-    ResponseEntity<WalletInfo> settle(@Valid @RequestBody WalletSettleRequest request);
+    ResponseEntity<WalletInfo> settle(
+            @RequestHeader("Member-Id") UUID memberId,
+            @Valid @RequestBody WalletSettleRequest request
+    );
 
 }

--- a/settlement-service/src/main/java/com/node5/settlementservice/settlement/client/ShopClient.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/settlement/client/ShopClient.java
@@ -1,0 +1,16 @@
+package com.node5.settlementservice.settlement.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "shop-service")
+public interface ShopClient {
+
+    @GetMapping("internal/shops/{shopId}/member-id")
+    ResponseEntity<String> getMemberIdByShopId(@PathVariable UUID shopId);
+
+}


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #151

## 📌 개요
- 정산 중 예치금 정산 API 요청 시 필요한 헤더 요청값(Member-Id) 추가

## ✨ 작업 내용
- 정산 중 예치금 정산 API 요청 시 필요한 헤더 요청값(Member-Id)을 추가했습니다.
- 현재 정산 테이블에 shopId에 대한 정보만 있는 관계로, memberId 값은 Shop 도메인의 API를 호출해서 얻도록 해두었습니다.
- 정산을 위해 매일 구매확정된 상품 목록을 order -> settlement로 보내는 스케줄러의 cron 값을 환경변수 처리했습니다. 

## 🧪 테스트 방법
- 테스트한 방법을 작성해주세요.

## 🔗 참고 사항 : 
- 스크린샷, 참고 문서 등

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
