### PR TITLE
fix: 주문 생성 후 결제 완료 시 주문 상태를 포함한 결제일시를 함께 저장하도록 수정

### DIFF
--- a/order-service/src/main/java/com/node5/orderservice/order/application/OrderService.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/application/OrderService.java
@@ -73,7 +73,7 @@ public class OrderService {
             ResponseEntity<WalletInfo> response = billingClient.withdraw(memberId, new WalletWithdrawRequest(order.getId(), roundedAmount.longValue()));
 
             if (response.getStatusCode().is2xxSuccessful()) {
-                orderTransactionService.updateOrderStatus(orderId, PAID);
+                saved.markAsPaid(LocalDateTime.now());
             }
         } catch(FeignException e) {
             orderTransactionService.updateOrderStatus(orderId, PAYMENT_FAILED);


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #161 

## 📌 개요
- 주문 상태 업데이트가 안되는 문제를 해결했습니다.

## ✨ 작업 내용
- 주문 생성 후 결제 완료 시 주문 상태를 포함한 결제일시를 함께 저장하는 이전 메소드를 사용하도록 수정했습니다. 

## 🧪 테스트 방법
- Swagger 통해 테스트해서 주문 생성 시 결제일시가 함께 저장되어 스케줄러를 통한 주문 상태 업데이트가 제대로 되는 것을 확인했습니다. 

## 🔗 참고 사항 : 
- 스크린샷, 참고 문서 등

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
