### PR TITLE
fix: 전체 판매자에 대한 정산 배치 실행 중 발생하는 오류 해결

### DIFF
--- a/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementBatchConfig.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementBatchConfig.java
@@ -74,15 +74,15 @@ public class SettlementBatchConfig {
 
                     if(shopParam != null && !shopParam.isEmpty()){
                         UUID shopId = UUID.fromString(shopParam);
-                        log.info("특정 판매자에 대한 정산 실행 - Shop: {}, Period: {} ~ {}", shopId, startDate, endDate);
+                        log.info("[BatchId: {}] 특정 판매자 정산 시작 (shopId: {}, period: {} ~ {})", batchId, shopId, startDate, endDate);
                         pendingData = sourceRepository.findPendingByShopAndPeriod(shopId, startDateTime, endDateTimePlusOneDay);
                     }else{
-                        log.info("전체 판매자에 대한 정산 실행 - Period: {} ~ {}", startDate, endDate);
+                        log.info("[BatchId: {}] 전체 판매자 정산 시작 (period: {} ~ {})", batchId, startDate, endDate);
                         pendingData = sourceRepository.findPendingByPeriod(startDateTime, endDateTimePlusOneDay);
                     }
 
                     if (pendingData.isEmpty()) {
-                        log.info("정산할 데이터 없음");
+                        log.info("[BatchId: {}] 정산할 데이터 없음", batchId);
                         return RepeatStatus.FINISHED;
                     }
 
@@ -93,7 +93,7 @@ public class SettlementBatchConfig {
                     // 3-1. 판매자 ID별로 SettlementSource 데이터 그룹핑
                     Map<UUID, List<SettlementSource>> groupedByShop = pendingData.stream()
                             .collect(Collectors.groupingBy(SettlementSource::getShopId));
-                    log.info("총 {}명의 판매자 정산 처리 중...", groupedByShop.size());
+                    log.info("[BatchId: {}] 총 {}명의 판매자 정산 처리 중...", batchId, groupedByShop.size());
 
                     // 3-2. 판매자별 정산 실행
                     groupedByShop.forEach((shopId, shopDataList) -> {
@@ -134,12 +134,13 @@ public class SettlementBatchConfig {
                         try {
                             // 에치금 정산 API 요청
                             BigDecimal roundedAmount = result.getPayoutAmount().setScale(0, RoundingMode.HALF_UP);
-                            ResponseEntity<String> shopResponse = shopClient.getMemberIdByShopId(UUID.fromString(shopParam));
+                            ResponseEntity<String> shopResponse = shopClient.getMemberIdByShopId(result.getShopId());
                             String memberId = null;
 
                             if(shopResponse.getStatusCode().is2xxSuccessful()){
                                 memberId = shopResponse.getBody();
                             }
+                            log.info("[BatchId: {}] 정산금 지급 예정 (shopId: {}, memberId: {})", batchId, result.getShopId(), memberId);
                             ResponseEntity<WalletSettleInfo> walletResponse = billingClient.settle(UUID.fromString(memberId), new WalletSettleRequest(result.getId(), roundedAmount.longValue()));
 
                             result.updatePayoutAt(walletResponse.getBody().payoutAt());
@@ -160,14 +161,14 @@ public class SettlementBatchConfig {
                     // [6] 정산금 지급 결과 저장
                     resultRepository.saveAll(resultList);
 
-                    if (!failedResults.isEmpty()) {
-                        log.error("=== [정산금 지급] 총 성공: {}건, 총 실패: {}건 ===",
-                                resultList.size() - failedResults.size(), failedResults.size());
-                        failedResults.forEach(r -> {
-                            log.error("  - Settlement Id: {}, Shop Id: {}, errorMsg: {}", r.getId(), r.getShopId(), r.getErrorMsg());
-                        });
+                    if (failedResults.isEmpty()) {
+                        log.info("[BatchId: {}] 정산금 지급 완료 (총 {}건 전원 성공)", batchId, resultList.size());
                     } else {
-                        log.info("=== [정산금 지급] 전체 {}건 모두 성공 ===", resultList.size());
+                        log.error("BatchId: {}] 정산금 지급 종료 (성공: {}건, 실패: {}건)",
+                                batchId, resultList.size() - failedResults.size(), failedResults.size());
+                        failedResults.forEach(r -> {
+                            log.error("  - (지급 실패 정보) shopId: {}, errorMsg: {}", r.getShopId(), r.getErrorMsg());
+                        });
                     }
 
                     return RepeatStatus.FINISHED;

--- a/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementScheduler.java
+++ b/settlement-service/src/main/java/com/node5/settlementservice/settlement/batch/SettlementScheduler.java
@@ -32,7 +32,7 @@ public class SettlementScheduler {
     private boolean settlementAsyncEnabled;
     private final SettlementSourceRepository settlementSourceRepository;
 
-    @Scheduled(cron = "${spring.task.scheduling.cron.settlement:0 */1 * * * *}")
+    @Scheduled(cron = "${spring.task.scheduling.cron.settlement:0 */10 * * * *}")
     public void runMonthlySettlement() {
         YearMonth previousMonth = YearMonth.now().minusMonths(1);
 
@@ -46,24 +46,16 @@ public class SettlementScheduler {
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTimePlusOneDay = endDate.plusDays(1).atStartOfDay();
 
-        log.info("** Starting monthly settlement jobs for period: {} to {}", startDate, endDate);
-
         // 1. SettlementSource에서 정산 대상 기간 동안 거래 기록이 있는 판매자 ID만 조회
         List<UUID> shopIds = settlementSourceRepository.findDistinctShopIds(startDateTime, endDateTimePlusOneDay);
 
-//        // 테스트
-//        List<UUID> shopIds = List.of(
-//                UUID.fromString("10000000-0000-0000-0000-000000000001"),
-//                UUID.fromString("20000000-0000-0000-0000-000000000002")
-//        );
-
         if (shopIds.isEmpty()) {
-            log.info("** No settlement source found for the period. Skipping job execution.");
+            log.info("** [월간 정산 스케줄러] 해당 기간 내 정산 대상 데이터가 없으므로 Job 실행없이 종료");
             return;
         }
 
         // 2. 판매자별 Job 호출
-        log.info("** Scheduled settlement jobs for {} shops", shopIds.size());
+        log.info("** [월간 정산 스케줄러] 시작 (period: {} ~ {}, target: {} shops)", startDate, endDate, shopIds.size());
         shopIds.forEach(shopId -> runJobForShop(shopId, startDateStr, endDateStr));
     }
 
@@ -79,9 +71,9 @@ public class SettlementScheduler {
                             .toJobParameters();
 
                     jobLauncher.run(shopSettlementJob, params);
-                    log.info("** Settlement job triggered for shop {} in period {} - {}", shopId, startDate, endDate);
+                    log.info("** [정산 Job 완료] shopId: {}, period: {} ~ {}", shopId, startDate, endDate);
                 } catch (Exception ex) {
-                    log.error("** Failed to run settlement job for shop {}", shopId, ex);
+                    log.error("** [정산 Job 오류] shopId: {}, period: {} ~ {}, errorMsg: {}", shopId, startDate, endDate, ex.getMessage(), ex);
                 }
             };
 
@@ -91,7 +83,7 @@ public class SettlementScheduler {
                 executeJob.run();
             }
         } catch (Exception ex) {
-            log.error("** Failed to run settlement job for shop {}", shopId, ex);
+            log.error("** [정산 스케줄링 실패] shopId: {}, errorMsg: {}", shopId, ex.getMessage(), ex);
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #178 

## 📌 개요
- 전체 판매자에 대한 정산 배치 실행 중 정산금 지급 과정에서 발생하는 오류 해결

## ✨ 작업 내용
- 정산 중 정산금 지급 로직 실행 시 고정된 shopParam이 아닌 resultList의 요소별 shopId를 사용하도록 수정
- 정산 배치 실행 관련 로그 정리
- 수동 배치 실행 테스트를 위한 정산 배치 스케줄러 시간 임시 조정 (1m -> 10m) (로컬용)

## 🧪 테스트 방법
- Swagger를 통해 전체 판매자에 대한 정산 실행, 특정 판매자에 대한 정산 실행 테스트를 완료했습니다.

## 🔗 참고 사항
- 다음 주 리팩토링을 통해 SettlementSource 데이터 조회 및 정산금 계산 로직과 정산금 지급 로직을 별도의 step으로 분리할 예정입니다.

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.

## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
