### PR TITLE
test: 검색 서비스 단위 테스트 전환 및 외부 인프라 의존 테스트 비활성화

### DIFF
--- a/catalog-service/src/test/java/com/node5/catalogservice/CatalogServiceApplicationTests.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/CatalogServiceApplicationTests.java
@@ -1,21 +1,13 @@
 package com.node5.catalogservice;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(properties = {
-	"spring.cloud.config.enabled=false",
-	"spring.cloud.config.fail-fast=false",
-	"spring.config.import="
-})
+@SpringBootTest
 @ActiveProfiles("test")
-@DisabledIfEnvironmentVariable(
-	named = "CI",
-	matches = "true",
-	disabledReason = "CI 환경에서는 전체 컨텍스트 로딩 테스트를 건너뜁니다."
-)
+@EnabledIfSystemProperty(named = "integrationTest", matches = "true")
 class CatalogServiceApplicationTests {
 
 	@Test

--- a/catalog-service/src/test/java/com/node5/catalogservice/search/application/ProductSearchServiceTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/search/application/ProductSearchServiceTest.java
@@ -1,161 +1,170 @@
 package com.node5.catalogservice.search.application;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
-import org.springframework.context.annotation.Import;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.IndexOperations;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import com.node5.catalogservice.config.search.SearchIndexNameConfig;
 import com.node5.catalogservice.product.domain.ProductCategory;
 import com.node5.catalogservice.search.application.dto.ProductSearchCommand;
 import com.node5.catalogservice.search.application.dto.ProductSearchResponse;
+import com.node5.catalogservice.search.application.port.ProductSearchPort;
+import com.node5.catalogservice.search.application.query.QueryNormalizer;
 import com.node5.catalogservice.search.domain.ProductDocument;
 import com.node5.catalogservice.search.domain.ProductSearchSort;
-import com.node5.catalogservice.search.infrastructure.ProductSearchRepository;
-import com.node5.catalogservice.search.infrastructure.elasticsearch.ElasticsearchProductSearchAdapter;
+import com.node5.catalogservice.search.exception.SearchErrorCode;
+import com.node5.common.exception.BaseException;
 
-/**
- * NOTE:
- * 이 테스트는 실제 Elasticsearch 인덱스를 생성하므로
- * CI 환경에서는 실행되지 않도록 조건부로 비활성화되어 있습니다.
- */
-@DataElasticsearchTest(properties = {
-	"spring.cloud.config.enabled=false",
-	"spring.cloud.config.fail-fast=false",
-	"spring.config.import="
-})
-@ActiveProfiles("test")
-@Import({
-	ProductSearchService.class,
-	ElasticsearchProductSearchAdapter.class,
-	SearchIndexNameConfig.class
-})
-@DisabledIfEnvironmentVariable(
-	named = "CI",
-	matches = "true",
-	disabledReason = "CI 환경에서는 검색 테스트를 건너뜁니다."
-)
-public class ProductSearchServiceTest {
+@ExtendWith(MockitoExtension.class)
+class ProductSearchServiceTest {
 
 	private static final PageRequest DEFAULT_PAGE = PageRequest.of(0, 10);
 
-	@MockitoBean
-	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+	@Mock
+	private ProductSearchPort productSearchPort;
 
-	@Autowired
-	private ProductSearchRepository productSearchRepository;
+	@Mock
+	private QueryNormalizer queryNormalizer;
 
-	@Autowired
+	@InjectMocks
 	private ProductSearchService productSearchService;
 
-	@Autowired
-	private ElasticsearchOperations operations;
+	@Test
+	void 가격범위가_완성되지_않으면_PRICE_RANGE_INCOMPLETE_BaseException() {
+		// given
+		ProductSearchCommand cmd = searchCommand("테스트", null, null, 1000, null, null);
 
-	@BeforeEach
-	void setup() {
-		IndexOperations indexOps = operations.indexOps(ProductDocument.class);
+		// when
+		BaseException ex = catchThrowableOfType(
+			() -> productSearchService.search(cmd, DEFAULT_PAGE),
+			BaseException.class
+		);
 
-		if (!indexOps.exists()) {
-			indexOps.create();
-			indexOps.putMapping();
-		}
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(SearchErrorCode.PRICE_RANGE_INCOMPLETE);
+		then(queryNormalizer).shouldHaveNoInteractions();
+		then(productSearchPort).shouldHaveNoInteractions();
+	}
 
-		productSearchRepository.deleteAll();
-		indexOps.refresh();
+	@Test
+	void 가격범위에서_최소값이_최대값보다_크면_INVALID_PRICE_RANGE_BaseException() {
+		// given
+		ProductSearchCommand cmd = searchCommand("테스트", null, null, 5000, 1000, null);
 
+		// when
+		BaseException ex = catchThrowableOfType(
+			() -> productSearchService.search(cmd, DEFAULT_PAGE),
+			BaseException.class
+		);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(SearchErrorCode.INVALID_PRICE_RANGE);
+		then(queryNormalizer).shouldHaveNoInteractions();
+		then(productSearchPort).shouldHaveNoInteractions();
+	}
+
+	@Test
+	void 검색_요청시_키워드를_정규화한_커맨드로_port를_호출한다() {
+		// given
+		UUID shopId = uuid();
+
+		ProductSearchCommand cmd = searchCommand(
+			"  Te-ST_/키워드  ",
+			shopId,
+			ProductCategory.SERVICE_SUBSCRIPTION,
+			1000,
+			5000,
+			ProductSearchSort.LATEST
+		);
+
+		given(queryNormalizer.normalize(cmd.keyword())).willReturn("te st 키워드");
+		given(productSearchPort.search(any(ProductSearchCommand.class), any()))
+			.willReturn(Page.empty(DEFAULT_PAGE));
+
+		// when
+		productSearchService.search(cmd, DEFAULT_PAGE);
+
+		// then
+		ArgumentCaptor<ProductSearchCommand> captor = ArgumentCaptor.forClass(ProductSearchCommand.class);
+		then(productSearchPort).should().search(captor.capture(), eq(DEFAULT_PAGE));
+
+		ProductSearchCommand sent = captor.getValue();
+		assertThat(sent.keyword()).isEqualTo("te st 키워드");
+		assertThat(sent.shopId()).isEqualTo(shopId);
+		assertThat(sent.category()).isEqualTo(ProductCategory.SERVICE_SUBSCRIPTION);
+		assertThat(sent.minPrice()).isEqualTo(1000);
+		assertThat(sent.maxPrice()).isEqualTo(5000);
+		assertThat(sent.sort()).isEqualTo(ProductSearchSort.LATEST);
+
+		then(queryNormalizer).should().normalize(cmd.keyword());
+	}
+
+	@Test
+	void 검색_성공시_ProductDocument를_ProductSearchResponse로_매핑한다() {
+		// given
 		LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0);
 
-		productSearchRepository.saveAll(List.of(
-			new ProductDocument("1", "1", "테스트 상품", "테스트 상품", "TEST",
-				"product/test-thumb-1.png", 1000L, "ON_SALE", base.plusDays(1)),
-			new ProductDocument("2", "2", "사과 상품", "사과 상품", "FOOD",
-				"product/apple-thumb.png", 2000L, "ON_SALE", base.plusDays(2)),
-			new ProductDocument("3", "3", "숨긴 상품", "숨긴 상품", "TEST",
-				"product/hidden-thumb.png", 5000L, "HIDDEN", base.plusDays(3))
-		));
+		ProductSearchCommand cmd = searchCommand("테스트", null, null, null, null, null);
 
-		indexOps.refresh();
-	}
+		given(queryNormalizer.normalize(cmd.keyword())).willReturn("테스트");
 
-	@Test
-	void 검색_키워드만_사용하면_이름_포함된_상품만_반환된다() {
+		ProductDocument d1 = new ProductDocument(
+			"1", "1", "테스트 상품", "테스트 상품", "TEST",
+			"product/test-thumb-1.png", 1000L, "ON_SALE", base.plusDays(1)
+		);
+		ProductDocument d2 = new ProductDocument(
+			"2", "2", "사과 상품", "사과 상품", "FOOD_BEVERAGE",
+			"product/apple-thumb.png", 2000L, "ON_SALE", base.plusDays(2)
+		);
+
+		Page<ProductDocument> docs = new PageImpl<>(List.of(d1, d2), DEFAULT_PAGE, 2);
+		given(productSearchPort.search(any(ProductSearchCommand.class), any()))
+			.willReturn(docs);
+
 		// when
-		Page<ProductSearchResponse> result =
-			productSearchService.search(command("테스트", null, null, null, null, null), DEFAULT_PAGE);
-
-		// then
-		assertThat(result.getContent()).hasSize(1);
-		assertThat(result.getContent().get(0).name()).contains("테스트");
-	}
-
-	@Test
-	void 정렬_조건을_주지_않으면_기본값은_LATEST이다() {
-		// when
-		Page<ProductSearchResponse> result =
-			productSearchService.search(command(null, null, null, null, null, null), DEFAULT_PAGE);
-
-		// then
-		assertThat(result.getContent())
-			.extracting(ProductSearchResponse::createdAt)
-			.isSortedAccordingTo(Comparator.reverseOrder());
-	}
-
-	@Test
-	void 정렬_LOW_PRICE_이면_가격_오름차순으로_정렬된다() {
-		// when
-		Page<ProductSearchResponse> result =
-			productSearchService.search(command(null, null, null, null, null, ProductSearchSort.LOW_PRICE), DEFAULT_PAGE);
+		Page<ProductSearchResponse> result = productSearchService.search(cmd, DEFAULT_PAGE);
 
 		// then
 		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getContent())
-			.extracting(ProductSearchResponse::price)
-			.isSorted();
+
+		ProductSearchResponse r1 = result.getContent().get(0);
+		assertThat(r1.productId()).isEqualTo("1");
+		assertThat(r1.shopId()).isEqualTo("1");
+		assertThat(r1.name()).isEqualTo("테스트 상품");
+		assertThat(r1.category()).isEqualTo("TEST");
+		assertThat(r1.thumbnailKey()).isEqualTo("product/test-thumb-1.png");
+		assertThat(r1.price()).isEqualTo(1000L);
+		assertThat(r1.status()).isEqualTo("ON_SALE");
+		assertThat(r1.createdAt()).isEqualTo(base.plusDays(1));
+
+		ProductSearchResponse r2 = result.getContent().get(1);
+		assertThat(r2.productId()).isEqualTo("2");
+		assertThat(r2.shopId()).isEqualTo("2");
+		assertThat(r2.name()).isEqualTo("사과 상품");
+		assertThat(r2.category()).isEqualTo("FOOD_BEVERAGE");
+		assertThat(r2.thumbnailKey()).isEqualTo("product/apple-thumb.png");
+		assertThat(r2.price()).isEqualTo(2000L);
+		assertThat(r2.status()).isEqualTo("ON_SALE");
+		assertThat(r2.createdAt()).isEqualTo(base.plusDays(2));
 	}
 
-	@Test
-	void 정렬_HIGH_PRICE_이면_가격_내림차순으로_정렬된다() {
-		// when
-		Page<ProductSearchResponse> result =
-			productSearchService.search(command(null, null, null, null, null, ProductSearchSort.HIGH_PRICE), DEFAULT_PAGE);
-
-		// then
-		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getContent())
-			.extracting(ProductSearchResponse::price)
-			.isSortedAccordingTo(Comparator.reverseOrder());
+	private static UUID uuid() {
+		return UUID.randomUUID();
 	}
 
-	@Test
-	void 항상_ON_SALE_상태의_상품만_검색된다() {
-		// when
-		Page<ProductSearchResponse> result =
-			productSearchService.search(command(null, null, null, null, null, null), DEFAULT_PAGE);
-
-		// then
-		assertThat(result.getContent())
-			.hasSize(2)
-			.extracting(ProductSearchResponse::status)
-			.containsOnly("ON_SALE");
-	}
-
-	private ProductSearchCommand command(
+	private ProductSearchCommand searchCommand(
 		String keyword,
 		UUID shopId,
 		ProductCategory category,


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #326 

## 📌 개요
- DataElasticsearchTest 기반 검색 테스트에서 컨텍스트 로드 이슈가 발생하여, 검색 서비스 테스트를 Mockito 기반 단위 테스트로 전환합니다.

## ✨ 작업 내용
- 검색 서비스 단위 테스트 전환
- 외부 인프라 의존 테스트 비활성화

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
