### PR TITLE
feat: 판매 중 상품 ID 목록 조회 내부 API 추가

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
@@ -159,6 +159,13 @@ public class ProductService {
 	}
 
 	@Transactional(readOnly = true)
+	public List<UUID> getOnSaleProductIds(Pageable pageable) {
+		return productRepository.findByStatus(ProductStatus.ON_SALE, pageable)
+			.map(Product::getId)
+			.getContent();
+	}
+
+	@Transactional(readOnly = true)
 	public boolean isReviewable(UUID productId) {
 		return productRepository.findByIdAndStatus(productId, ProductStatus.ON_SALE).isPresent();
 	}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,5 +57,10 @@ public class ProductInternalController {
 			.toList();
 
 		return ResponseEntity.ok(new ProductSummaryListResponse(summaries));
+	}
+
+	@GetMapping("/ids")
+	public ResponseEntity<List<UUID>> getProductIds(@ParameterObject Pageable pageable) {
+		return ResponseEntity.ok(productService.getOnSaleProductIds(pageable));
 	}
 }


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #339 

## 📌 개요
- 판매 중인 모든 상품 ID를 페이지 단위로 제공하는 내부 API를 추가합니다.

## ✨ 작업 내용
- 판매 중(ON_SALE)인 상품 ID 목록을 페이지 단위로 조회

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
