### PR TITLE
fix: 취향 문장 도출을 위한 LLM 프롬프트 수정

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
@@ -35,7 +35,7 @@ public class ProductInternalController {
 		return ResponseEntity.ok(productService.getShopIdsByProductIds(productIds));
 	}
 
-	@GetMapping("/getProductsByIds")
+	@PostMapping("/getProductsByIds")
 	public ResponseEntity<ProductSummaryListResponse> getProductsByIds(
 		@RequestHeader("Member-Id") UUID memberId,
 		@Valid @RequestBody ProductIdsRequest request

--- a/support-service/src/main/java/com/node5/supportservice/global/openfeign/client/CatalogClient.java
+++ b/support-service/src/main/java/com/node5/supportservice/global/openfeign/client/CatalogClient.java
@@ -7,10 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -18,7 +15,7 @@ import java.util.UUID;
 @FeignClient(name = "catalog-service", contextId = "catalogClient")
 public interface CatalogClient {
 
-    @GetMapping("/internal/products/getProductsByIds")
+    @PostMapping("/internal/products/getProductsByIds")
     ResponseEntity<ProductSummaryListResponse> getProductsByIds(
             @RequestHeader("Member-Id") UUID memberId,
             @Valid @RequestBody ProductIdsRequest request

--- a/support-service/src/main/java/com/node5/supportservice/recommendation/application/RecommendationService.java
+++ b/support-service/src/main/java/com/node5/supportservice/recommendation/application/RecommendationService.java
@@ -154,10 +154,11 @@ public class RecommendationService {
     }
 
     private String promptTemplate() {
-        return "cartItems 70%, orderItems 30% 비중으로 반영해줘."
+        return "cartItems 60%, orderItems 40% 비중으로 반영하되(둘 중 하나만 있을 경우엔 해당 데이터만 100% 활용)"
                 + "장바구니, 주문 내역에서 공통으로 반복되는 속성(카테고리/기능/용도/성향)을 우선 사용해줘."
-                + "형식: \"사용자는 최근 [주요 관심사 1~2개]와 [보조 관심사 1~2개]에 관심이 높고, "
-                + "[주문 내역 기반 생활 패턴 1~2개]을 보인다. 특히 [장바구니 기반 핵심 속성 1~2개]을 선호한다.\"";
+                + "데이터가 없을 경우, 최근 2030 인기 라이프스타일 기반의 대중적인 취향으로 생성해줘."
+                + "응답 형식: \"사용자는 최근 [주요 관심사 1~2개]와 [보조 관심사 1~2개]에 관심이 높고, "
+                + "[생활 패턴 1~2개]을 보인다. 특히 [핵심 선호 속성 1~2개]을 선호한다.\"";
     }
 
     public record Result(String tasteSummary, float[] embedding, List<UUID> existedProductIds) {}


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #386 

## 📌 개요
- 장바구니/주문내역 기반 상품 추천 기능에서 취향 문장 도출을 위한 LLM 호출 프롬프트를 수정합니다.

## ✨ 작업 내용
- 장바구니/주문 상품 정보 조회를 위한 CatalogClient 연동 시 HTTP 메소드 GET -> POST 변경
- 취향 문장 추출을 위한 LLM 호출 프롬프트 추가

## 🧪 테스트 방법

## 🔗 참고 사항

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
