### PR TITLE
feat: 상점 삭제 이벤트 수신 시 상품 영구 중지 처리

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductDiscontinueService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductDiscontinueService.java
@@ -1,0 +1,22 @@
+package com.node5.catalogservice.product.application;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.node5.catalogservice.product.domain.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDiscontinueService {
+
+	private final ProductRepository productRepository;
+
+	@Transactional
+	public int discontinueByShopId(UUID shopId) {
+		return productRepository.discontinueByShopId(shopId);
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductRepository.java
@@ -23,4 +23,6 @@ public interface ProductRepository {
 	List<Product> findAllByIdIn(Collection<UUID> ids);
 
 	List<Product> findAllByIdInAndStatus(Collection<UUID> ids, ProductStatus status);
+
+	int discontinueByShopId(UUID shopId);
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductJpaRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductJpaRepository.java
@@ -8,9 +8,13 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.domain.ProductStatus;
+
+import jakarta.transaction.Transactional;
 
 public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
 
@@ -23,4 +27,14 @@ public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
 	List<Product> findByIdIn(Collection<UUID> ids);
 
 	List<Product> findByIdInAndStatus(Collection<UUID> ids, ProductStatus status);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Transactional
+	@Query("""
+		update Product p
+		   set p.status = 'DISCONTINUED'
+		 where p.shopId = :shopId
+		   and p.status <> 'DISCONTINUED'
+	""")
+	int discontinueByShopId(UUID shopId);
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductRepositoryAdapter.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductRepositoryAdapter.java
@@ -55,4 +55,9 @@ public class ProductRepositoryAdapter implements ProductRepository {
 	public List<Product> findAllByIdInAndStatus(Collection<UUID> ids, ProductStatus status) {
 		return productJpaRepository.findByIdInAndStatus(ids, status);
 	}
+
+	@Override
+	public int discontinueByShopId(UUID shopId) {
+		return productJpaRepository.discontinueByShopId(shopId);
+	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/kafka/KafkaShopDeletedEventConsumer.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/kafka/KafkaShopDeletedEventConsumer.java
@@ -1,0 +1,43 @@
+package com.node5.catalogservice.product.infrastructure.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.node5.catalogservice.product.application.ProductDiscontinueService;
+import com.node5.common.event.ShopDeletedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaShopDeletedEventConsumer {
+
+	private final ProductDiscontinueService productDiscontinueService;
+
+	@KafkaListener(
+		topics = "${app.kafka.topics.shop-deleted}",
+		groupId = "${spring.kafka.consumer.group-id:catalog-service-product}"
+	)
+	public void consume(ShopDeletedEvent event) {
+
+		if (event == null || event.shopId() == null) {
+			log.warn("가게 삭제 이벤트가 null이거나 shopId가 없습니다.");
+			return;
+		}
+
+		String shopId = event.shopId().toString();
+
+		log.info("Kafka 가게 삭제 이벤트 수신, shopId={}", shopId);
+
+		try {
+			int updatedCount = productDiscontinueService.discontinueByShopId(event.shopId());
+			log.info("가게 상품 영구 중지 완료, shopId={}, updatedCount={}", shopId, updatedCount);
+
+		} catch (Exception e) {
+			log.error("가게 상품 영구 중지 실패, shopId={}", shopId, e);
+			throw e;
+		}
+	}
+}

--- a/config/config/catalog-service.yaml
+++ b/config/config/catalog-service.yaml
@@ -1,6 +1,5 @@
 spring:
   datasource:
-    # Postgres 서버 타임존을 서울(KST)로 맞추기 위해 옵션 추가
     url: ${SPRING_DATASOURCE_URL}
     driver-class-name: org.postgresql.Driver
     username: ${SPRING_DATASOURCE_USERNAME}
@@ -22,6 +21,9 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
@@ -34,6 +36,7 @@ app:
   kafka:
     topics:
       member-deleted: member-service.member-deleted.v1
+      shop-deleted: member-service.shop-deleted.v1
       product-index: catalog-service.product-index.v1
       product-embedding: catalog-service.product-embedding.v1
       product-discontinued: catalog-service.product-discontinued.v1


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #435 

## 📌 개요
- 상점 삭제 이벤트(ShopDeletedEvent)를 수신하면, 해당 상점에 속한 모든 상품을 영구 판매 중단(DISCONTINUED) 상태로 전환합니다.

## ✨ 작업 내용
- ProductDiscontinueService.discontinueByShopId(shopId) 유스케이스 구현
- KafkaShopDeletedEventConsumer 추가 및 토픽/그룹ID 설정 반영

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
