### PR TITLE
feat: 검색 쿼리 빌더 분리 및 스폰서 상품 노출 기능 추가

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/mapper/ProductIndexEventMapper.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/mapper/ProductIndexEventMapper.java
@@ -28,6 +28,7 @@ public final class ProductIndexEventMapper {
 			product.getPrice().longValue(),
 			product.getStatus().name(),
 			product.getCreatedAt(),
+			product.getModifiedAt(),
 			type
 		);
 	}

--- a/common/src/main/java/com/node5/common/event/ProductIndexEvent.java
+++ b/common/src/main/java/com/node5/common/event/ProductIndexEvent.java
@@ -13,6 +13,7 @@ public record ProductIndexEvent(
 	long price,
 	String status,
 	LocalDateTime createdAt,
+	LocalDateTime modifiedAt,
 	ProductIndexEventType type
 ) {
 }

--- a/support-service/scripts/es/products-mapping.json
+++ b/support-service/scripts/es/products-mapping.json
@@ -25,6 +25,7 @@
   "mappings": {
     "properties": {
       "productId": { "type": "keyword" },
+      "shopId": { "type": "keyword" },
       "name": { "type": "text" },
       "name_autocomplete": {
         "type": "text",
@@ -32,7 +33,12 @@
         "search_analyzer": "autocomplete_search"
       },
       "category": { "type": "keyword" },
-      "status": { "type": "keyword" }
+      "thumbnailKey": { "type": "keyword" },
+      "price": { "type": "long" },
+      "status": { "type": "keyword" },
+      "isSponsored": { "type": "boolean" },
+      "createdAt": { "type": "date", "format": "strict_date_optional_time||epoch_millis" },
+      "modifiedAt": { "type": "date", "format": "strict_date_optional_time||epoch_millis" }
     }
   }
 }

--- a/support-service/src/main/java/com/node5/supportservice/search/application/ProductAutocompleteService.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/ProductAutocompleteService.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductAutocompleteService {
 
-	private static final int MIN_LENGTH = 2;
+	private static final int MIN_AUTOCOMPLETE_LENGTH = 2;
 
 	private final ProductSearchPort productSearchPort;
 	private final QueryNormalizer queryNormalizer;
@@ -25,10 +25,14 @@ public class ProductAutocompleteService {
 
 		String normalized = queryNormalizer.normalize(keyword);
 		if (normalized.isBlank()) return List.of();
-		if (normalized.length() < MIN_LENGTH) return List.of();
+		if (normalized.length() < MIN_AUTOCOMPLETE_LENGTH) return List.of();
 
 		List<String> raw = productSearchPort.autocomplete(new ProductAutocompleteCommand(normalized));
 
+		return postProcess(raw);
+	}
+
+	private List<String> postProcess(List<String> raw) {
 		return raw.stream()
 			.filter(StringUtils::hasText)
 			.map(String::trim)

--- a/support-service/src/main/java/com/node5/supportservice/search/application/ProductSearchService.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/ProductSearchService.java
@@ -1,6 +1,12 @@
 package com.node5.supportservice.search.application;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -18,14 +24,36 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductSearchService {
 
+	private static final int SPONSORED_LIMIT = 3;
+
 	private final ProductSearchPort productSearchPort;
 	private final QueryNormalizer queryNormalizer;
 
 	public Page<ProductSearchResponse> search(ProductSearchCommand command, Pageable pageable) {
 		validatePriceRange(command.minPrice(), command.maxPrice());
 
+		ProductSearchCommand normalizedCommand = normalize(command);
+
+		List<ProductDocument> sponsored = productSearchPort.searchSponsored(normalizedCommand, SPONSORED_LIMIT);
+		Page<ProductDocument> normalPage = productSearchPort.search(normalizedCommand, pageable);
+
+		Set<String> sponsoredIds = sponsored.stream()
+			.map(ProductDocument::getProductId)
+			.collect(Collectors.toSet());
+
+		List<ProductDocument> normalWithoutSponsored = normalPage.getContent().stream()
+			.filter(doc -> !sponsoredIds.contains(doc.getProductId()))
+			.toList();
+
+		List<ProductDocument> merged = mergePreserveOrder(sponsored, normalWithoutSponsored);
+		Page<ProductDocument> mergedPage = new PageImpl<>(merged, pageable, normalPage.getTotalElements());
+
+		return mergedPage.map(ProductSearchResponse::from);
+	}
+
+	private ProductSearchCommand normalize(ProductSearchCommand command) {
 		String normalizedKeyword = queryNormalizer.normalize(command.keyword());
-		ProductSearchCommand normalizedCommand = new ProductSearchCommand(
+		return new ProductSearchCommand(
 			normalizedKeyword,
 			command.shopId(),
 			command.category(),
@@ -33,9 +61,17 @@ public class ProductSearchService {
 			command.maxPrice(),
 			command.sort()
 		);
+	}
 
-		Page<ProductDocument> page = productSearchPort.search(normalizedCommand, pageable);
-		return page.map(ProductSearchResponse::from);
+	private List<ProductDocument> mergePreserveOrder(List<ProductDocument> sponsored, List<ProductDocument> normal) {
+		LinkedHashMap<String, ProductDocument> map = new LinkedHashMap<>();
+		for (ProductDocument d : sponsored) {
+			map.put(d.getProductId(), d);
+		}
+		for (ProductDocument d : normal) {
+			map.put(d.getProductId(), d);
+		}
+		return List.copyOf(map.values());
 	}
 
 	private void validatePriceRange(Integer minPrice, Integer maxPrice) {

--- a/support-service/src/main/java/com/node5/supportservice/search/application/SponsoredProductService.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/SponsoredProductService.java
@@ -1,0 +1,40 @@
+package com.node5.supportservice.search.application;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.stereotype.Service;
+
+import com.node5.supportservice.search.domain.ProductDocument;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SponsoredProductService {
+
+	private final ElasticsearchOperations elasticsearchOperations;
+
+	public void sponsor(UUID productId) {
+		updateSponsored(productId, true);
+	}
+
+	public void unsponsor(UUID productId) {
+		updateSponsored(productId, false);
+	}
+
+	private void updateSponsored(UUID productId, boolean isSponsored) {
+
+		Document doc = Document.from(Map.of("isSponsored", isSponsored));
+
+		UpdateQuery updateQuery = UpdateQuery.builder(productId.toString())
+			.withDocument(doc)
+			.build();
+
+		var index = elasticsearchOperations.getIndexCoordinatesFor(ProductDocument.class);
+		elasticsearchOperations.update(updateQuery, index);
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/application/dto/ProductSearchResponse.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/dto/ProductSearchResponse.java
@@ -24,7 +24,7 @@ public record ProductSearchResponse(
 			doc.getThumbnailKey(),
 			doc.getPrice(),
 			doc.getStatus(),
-			doc.getCreatedAt()
+			LocalDateTime.parse(doc.getCreatedAt())
 		);
 	}
 }

--- a/support-service/src/main/java/com/node5/supportservice/search/application/port/ProductSearchPort.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/port/ProductSearchPort.java
@@ -14,4 +14,6 @@ public interface ProductSearchPort {
 	Page<ProductDocument> search(ProductSearchCommand command, Pageable pageable);
 
 	List<String> autocomplete(ProductAutocompleteCommand command);
+
+	List<ProductDocument> searchSponsored(ProductSearchCommand command, int limit);
 }

--- a/support-service/src/main/java/com/node5/supportservice/search/domain/ProductDocument.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/domain/ProductDocument.java
@@ -45,11 +45,11 @@ public class ProductDocument {
 	@Field(type = FieldType.Boolean)
 	private Boolean isSponsored;
 
-	@Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss")
-	private LocalDateTime createdAt;
+	@Field(type = FieldType.Date)
+	private String createdAt;
 
-	@Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss")
-	private LocalDateTime modifiedAt;
+	@Field(type = FieldType.Date)
+	private String modifiedAt;
 
 	protected ProductDocument() {
 	}
@@ -64,8 +64,8 @@ public class ProductDocument {
 		Long price,
 		String status,
 		Boolean isSponsored,
-		LocalDateTime createdAt,
-		LocalDateTime modifiedAt
+		String createdAt,
+		String modifiedAt
 	) {
 		this.productId = id;
 		this.shopId = shopId;

--- a/support-service/src/main/java/com/node5/supportservice/search/domain/ProductDocument.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/domain/ProductDocument.java
@@ -42,8 +42,14 @@ public class ProductDocument {
 	@Field(type = FieldType.Keyword)
 	private String status;
 
+	@Field(type = FieldType.Boolean)
+	private Boolean isSponsored;
+
 	@Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss")
 	private LocalDateTime createdAt;
+
+	@Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss")
+	private LocalDateTime modifiedAt;
 
 	protected ProductDocument() {
 	}
@@ -57,7 +63,9 @@ public class ProductDocument {
 		String thumbnailKey,
 		Long price,
 		String status,
-		LocalDateTime createdAt
+		Boolean isSponsored,
+		LocalDateTime createdAt,
+		LocalDateTime modifiedAt
 	) {
 		this.productId = id;
 		this.shopId = shopId;
@@ -67,6 +75,8 @@ public class ProductDocument {
 		this.thumbnailKey = thumbnailKey;
 		this.price = price;
 		this.status = status;
+		this.isSponsored = isSponsored;
 		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
 	}
 }

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/ProductSearchRepository.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/ProductSearchRepository.java
@@ -1,8 +1,0 @@
-package com.node5.supportservice.search.infrastructure;
-
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-
-import com.node5.supportservice.search.domain.ProductDocument;
-
-public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, String> {
-}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/ElasticsearchProductSearchAdapter.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/ElasticsearchProductSearchAdapter.java
@@ -20,6 +20,7 @@ import com.node5.supportservice.search.domain.ProductDocument;
 import com.node5.supportservice.search.domain.ProductSearchSort;
 import com.node5.supportservice.search.infrastructure.elasticsearch.query.ProductAutocompleteQueryBuilder;
 import com.node5.supportservice.search.infrastructure.elasticsearch.query.ProductSearchQueryBuilder;
+import com.node5.supportservice.search.infrastructure.elasticsearch.query.SponsoredQueryBuilder;
 import com.node5.supportservice.search.infrastructure.elasticsearch.sort.ProductSortOptionsBuilder;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
@@ -34,12 +35,12 @@ public class ElasticsearchProductSearchAdapter implements ProductSearchPort {
 	private final ElasticsearchOperations elasticsearchOperations;
 
 	private final ProductAutocompleteQueryBuilder autocompleteQueryBuilder;
+	private final SponsoredQueryBuilder sponsoredQueryBuilder;
 	private final ProductSearchQueryBuilder searchQueryBuilder;
 	private final ProductSortOptionsBuilder sortOptionsBuilder;
 
 	@Override
 	public List<String> autocomplete(ProductAutocompleteCommand command) {
-
 		Query query = autocompleteQueryBuilder.build(command);
 
 		NativeQuery nativeQuery = new NativeQueryBuilder()
@@ -56,8 +57,25 @@ public class ElasticsearchProductSearchAdapter implements ProductSearchPort {
 	}
 
 	@Override
-	public Page<ProductDocument> search(ProductSearchCommand command, Pageable pageable) {
+	public List<ProductDocument> searchSponsored(ProductSearchCommand command, int limit) {
+		if (limit <= 0) return List.of();
 
+		Query query = sponsoredQueryBuilder.build(command);
+
+		NativeQuery nativeQuery = new NativeQueryBuilder()
+			.withQuery(query)
+			.withMaxResults(limit)
+			.build();
+
+		SearchHits<ProductDocument> hits = elasticsearchOperations.search(nativeQuery, ProductDocument.class);
+
+		return hits.getSearchHits().stream()
+			.map(hit -> hit.getContent())
+			.toList();
+	}
+
+	@Override
+	public Page<ProductDocument> search(ProductSearchCommand command, Pageable pageable) {
 		Query query = searchQueryBuilder.build(command);
 
 		ProductSearchSort sort = command.sort() != null ? command.sort() : ProductSearchSort.LATEST;

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/ElasticsearchProductSearchAdapter.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/ElasticsearchProductSearchAdapter.java
@@ -1,7 +1,6 @@
 package com.node5.supportservice.search.infrastructure.elasticsearch;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,11 +18,10 @@ import com.node5.supportservice.search.application.dto.ProductSearchCommand;
 import com.node5.supportservice.search.application.port.ProductSearchPort;
 import com.node5.supportservice.search.domain.ProductDocument;
 import com.node5.supportservice.search.domain.ProductSearchSort;
+import com.node5.supportservice.search.infrastructure.elasticsearch.query.ProductAutocompleteQueryBuilder;
+import com.node5.supportservice.search.infrastructure.elasticsearch.query.ProductSearchQueryBuilder;
+import com.node5.supportservice.search.infrastructure.elasticsearch.sort.ProductSortOptionsBuilder;
 
-import co.elastic.clients.elasticsearch._types.FieldValue;
-import co.elastic.clients.elasticsearch._types.SortOptions;
-import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import lombok.RequiredArgsConstructor;
 
@@ -35,28 +33,14 @@ public class ElasticsearchProductSearchAdapter implements ProductSearchPort {
 
 	private final ElasticsearchOperations elasticsearchOperations;
 
+	private final ProductAutocompleteQueryBuilder autocompleteQueryBuilder;
+	private final ProductSearchQueryBuilder searchQueryBuilder;
+	private final ProductSortOptionsBuilder sortOptionsBuilder;
+
 	@Override
 	public List<String> autocomplete(ProductAutocompleteCommand command) {
 
-		Query query = Query.of(q -> q.bool(b -> {
-
-			// filter:
-			// - 판매 중인 상품만 자동완성 대상
-			b.filter(f -> f.term(t -> t.field("status")
-				.value(FieldValue.of("ON_SALE"))));
-
-			// must:
-			// - 자동완성 필드(name_autocomplete)로 검색어 매칭
-			if (StringUtils.hasText(command.keyword())) {
-				b.must(m -> m.match(mm -> mm
-					.field("name_autocomplete")
-					.query(command.keyword())
-					.operator(Operator.And)
-				));
-			}
-
-			return b;
-		}));
+		Query query = autocompleteQueryBuilder.build(command);
 
 		NativeQuery nativeQuery = new NativeQueryBuilder()
 			.withQuery(query)
@@ -73,14 +57,15 @@ public class ElasticsearchProductSearchAdapter implements ProductSearchPort {
 
 	@Override
 	public Page<ProductDocument> search(ProductSearchCommand command, Pageable pageable) {
-		Query query = buildBoolQuery(command);
+
+		Query query = searchQueryBuilder.build(command);
 
 		ProductSearchSort sort = command.sort() != null ? command.sort() : ProductSearchSort.LATEST;
 
 		NativeQuery nativeQuery = new NativeQueryBuilder()
 			.withQuery(query)
 			.withPageable(pageable)
-			.withSort(buildSortOptions(sort))
+			.withSort(sortOptionsBuilder.build(sort))
 			.build();
 
 		SearchHits<ProductDocument> hits = elasticsearchOperations.search(nativeQuery, ProductDocument.class);
@@ -88,69 +73,5 @@ public class ElasticsearchProductSearchAdapter implements ProductSearchPort {
 		SearchPage<ProductDocument> page = SearchHitSupport.searchPageFor(hits, pageable);
 
 		return page.map(hit -> hit.getContent());
-	}
-
-	private Query buildBoolQuery(ProductSearchCommand command) {
-		return Query.of(q -> q.bool(b -> {
-
-			// filter:
-			// - 판매 중인 상품만 검색 대상
-			// - 결과를 걸러내는 조건 (점수에는 영향 없음)
-			b.filter(f -> f.term(t -> t.field("status")
-				.value(FieldValue.of("ON_SALE"))));
-
-			// filter:
-			// - 판매자 기준으로 결과 제한
-			if (command.shopId() != null) {
-				b.filter(f -> f.term(t -> t.field("shopId")
-					.value(FieldValue.of(command.shopId().toString()))));
-			}
-
-			// filter:
-			// - 카테고리 기준으로 결과 제한
-			if (command.category() != null) {
-				b.filter(f -> f.term(t -> t.field("category")
-					.value(FieldValue.of(command.category().name()))));
-			}
-
-			// must:
-			// - 검색어 매칭
-			// - 여기서 점수 계산됨 (결과 순서에 영향)
-			if (StringUtils.hasText(command.keyword())) {
-				b.must(m -> m.match(mm -> mm
-					.field("name")
-					.query(command.keyword())
-					.operator(Operator.And)
-				));
-			}
-
-			// filter:
-			// - 가격 범위로 결과 제한
-			// - 점수에는 영향 없음
-			if (command.minPrice() != null && command.maxPrice() != null) {
-				double min = command.minPrice().doubleValue();
-				double max = command.maxPrice().doubleValue();
-
-				b.filter(f -> f.range(r -> r
-					.number(n -> n
-						.field("price")
-						.gte(min)
-						.lte(max)
-					)
-				));
-			}
-
-			return b;
-		}));
-	}
-
-	private List<SortOptions> buildSortOptions(ProductSearchSort sort) {
-		Objects.requireNonNull(sort);
-
-		return switch (sort) {
-			case LATEST -> List.of(SortOptions.of(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc))));
-			case LOW_PRICE -> List.of(SortOptions.of(s -> s.field(f -> f.field("price").order(SortOrder.Asc))));
-			case HIGH_PRICE -> List.of(SortOptions.of(s -> s.field(f -> f.field("price").order(SortOrder.Desc))));
-		};
 	}
 }

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/query/ProductAutocompleteQueryBuilder.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/query/ProductAutocompleteQueryBuilder.java
@@ -1,0 +1,34 @@
+package com.node5.supportservice.search.infrastructure.elasticsearch.query;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.node5.supportservice.search.application.dto.ProductAutocompleteCommand;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
+@Component
+public class ProductAutocompleteQueryBuilder {
+
+	public Query build(ProductAutocompleteCommand command) {
+		return Query.of(q -> q.bool(b -> {
+
+			// filter: 판매 중인 상품만 자동완성 대상
+			b.filter(f -> f.term(t -> t.field("status")
+				.value(FieldValue.of("ON_SALE"))));
+
+			// must: 자동완성 필드(name_autocomplete) prefix 토큰 매칭
+			if (StringUtils.hasText(command.keyword())) {
+				b.must(m -> m.match(mm -> mm
+					.field("name_autocomplete")
+					.query(command.keyword())
+					.operator(Operator.And)
+				));
+			}
+
+			return b;
+		}));
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/query/ProductSearchQueryBuilder.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/query/ProductSearchQueryBuilder.java
@@ -1,0 +1,58 @@
+package com.node5.supportservice.search.infrastructure.elasticsearch.query;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.node5.supportservice.search.application.dto.ProductSearchCommand;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
+@Component
+public class ProductSearchQueryBuilder {
+
+	public Query build(ProductSearchCommand command) {
+		return Query.of(q -> q.bool(b -> {
+
+			// filter: 판매 중인 상품만 검색 대상
+			b.filter(f -> f.term(t -> t.field("status")
+				.value(FieldValue.of("ON_SALE"))));
+
+			// filter: 판매자 기준 제한
+			if (command.shopId() != null) {
+				b.filter(f -> f.term(t -> t.field("shopId")
+					.value(FieldValue.of(command.shopId().toString()))));
+			}
+
+			// filter: 카테고리 기준 제한
+			if (command.category() != null) {
+				b.filter(f -> f.term(t -> t.field("category")
+					.value(FieldValue.of(command.category().name()))));
+			}
+
+			// must: 검색어 매칭
+			if (StringUtils.hasText(command.keyword())) {
+				b.must(m -> m.match(mm -> mm
+					.field("name")
+					.query(command.keyword())
+					.operator(Operator.And)
+				));
+			}
+
+			// filter: 가격 범위 제한
+			if (command.minPrice() != null && command.maxPrice() != null) {
+				double min = command.minPrice().doubleValue();
+				double max = command.maxPrice().doubleValue();
+
+				b.filter(f -> f.range(r -> r.number(n -> n
+					.field("price")
+					.gte(min)
+					.lte(max)
+				)));
+			}
+
+			return b;
+		}));
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/query/SponsoredQueryBuilder.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/query/SponsoredQueryBuilder.java
@@ -1,0 +1,57 @@
+package com.node5.supportservice.search.infrastructure.elasticsearch.query;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.node5.supportservice.search.application.dto.ProductSearchCommand;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
+@Component
+public class SponsoredQueryBuilder {
+
+	public Query build(ProductSearchCommand command) {
+		return Query.of(q -> q.bool(b -> {
+
+			b.filter(f -> f.term(t -> t.field("status")
+				.value(FieldValue.of("ON_SALE"))));
+
+			// filter: 스폰서 기준
+			b.filter(f -> f.term(t -> t.field("isSponsored")
+				.value(FieldValue.of(true))));
+
+			if (command.shopId() != null) {
+				b.filter(f -> f.term(t -> t.field("shopId")
+					.value(FieldValue.of(command.shopId().toString()))));
+			}
+
+			if (command.category() != null) {
+				b.filter(f -> f.term(t -> t.field("category")
+					.value(FieldValue.of(command.category().name()))));
+			}
+
+			if (command.minPrice() != null && command.maxPrice() != null) {
+				double min = command.minPrice().doubleValue();
+				double max = command.maxPrice().doubleValue();
+
+				b.filter(f -> f.range(r -> r.number(n -> n
+					.field("price")
+					.gte(min)
+					.lte(max)
+				)));
+			}
+
+			if (StringUtils.hasText(command.keyword())) {
+				b.must(m -> m.match(mm -> mm
+					.field("name")
+					.query(command.keyword())
+					.operator(Operator.And)
+				));
+			}
+
+			return b;
+		}));
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/sort/ProductSortOptionsBuilder.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/elasticsearch/sort/ProductSortOptionsBuilder.java
@@ -1,0 +1,25 @@
+package com.node5.supportservice.search.infrastructure.elasticsearch.sort;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import com.node5.supportservice.search.domain.ProductSearchSort;
+
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+
+@Component
+public class ProductSortOptionsBuilder {
+
+	public List<SortOptions> build(ProductSearchSort sort) {
+		Objects.requireNonNull(sort);
+
+		return switch (sort) {
+			case LATEST -> List.of(SortOptions.of(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+			case LOW_PRICE -> List.of(SortOptions.of(s -> s.field(f -> f.field("price").order(SortOrder.Asc))));
+			case HIGH_PRICE -> List.of(SortOptions.of(s -> s.field(f -> f.field("price").order(SortOrder.Desc))));
+		};
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
@@ -34,7 +34,9 @@ public class KafkaProductIndexEventConsumer {
 				event.thumbnailKey(),
 				event.price(),
 				event.status(),
-				event.createdAt()
+				null,
+				event.createdAt(),
+				event.modifiedAt()
 			);
 
 			productSearchRepository.save(document);

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
@@ -1,11 +1,17 @@
 package com.node5.supportservice.search.infrastructure.kafka;
 
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import com.node5.common.event.ProductIndexEvent;
 import com.node5.supportservice.search.domain.ProductDocument;
-import com.node5.supportservice.search.infrastructure.ProductSearchRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +21,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class KafkaProductIndexEventConsumer {
 
-	private final ProductSearchRepository productSearchRepository;
+	DateTimeFormatter ES_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+	private final ElasticsearchOperations elasticsearchOperations;
 
 	@KafkaListener(topics = "catalog-service.product-index.v1", groupId = "support-service")
 	public void consume(ProductIndexEvent event) {
@@ -25,21 +33,25 @@ public class KafkaProductIndexEventConsumer {
 		log.info("Kafka 상품 색인 이벤트 수신, productId={}, type={}", productId, event.type());
 
 		try {
-			ProductDocument document = new ProductDocument(
-				productId,
-				event.shopId().toString(),
-				event.name(),
-				event.nameAutocomplete(),
-				event.category(),
-				event.thumbnailKey(),
-				event.price(),
-				event.status(),
-				null,
-				event.createdAt(),
-				event.modifiedAt()
-			);
+			Map<String, Object> doc = new HashMap<>();
+			doc.put("productId", productId);
+			doc.put("shopId", event.shopId().toString());
+			doc.put("name", event.name());
+			doc.put("name_autocomplete", event.nameAutocomplete());
+			doc.put("category", event.category());
+			doc.put("thumbnailKey", event.thumbnailKey());
+			doc.put("price", event.price());
+			doc.put("status", event.status());
+			doc.put("createdAt", event.createdAt().format(ES_DATE_TIME));
+			doc.put("modifiedAt", event.modifiedAt().format(ES_DATE_TIME));
 
-			productSearchRepository.save(document);
+			UpdateQuery updateQuery = UpdateQuery.builder(productId)
+				.withDocument(Document.from(doc))
+				.withDocAsUpsert(true)
+				.build();
+
+			var index = elasticsearchOperations.getIndexCoordinatesFor(ProductDocument.class);
+			elasticsearchOperations.update(updateQuery, index);
 
 			log.info("ES 상품 색인 완료, productId={}", productId);
 

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
@@ -45,7 +45,7 @@ public class KafkaProductIndexEventConsumer {
 			doc.put("createdAt", event.createdAt().format(ES_DATE_TIME));
 			doc.put("modifiedAt", event.modifiedAt().format(ES_DATE_TIME));
 
-			UpdateQuery updateQuery = UpdateQuery.builder(productId)
+			UpdateQuery updateQuery = UpdateQuery.builder(productId.toString())
 				.withDocument(Document.from(doc))
 				.withDocAsUpsert(true)
 				.build();

--- a/support-service/src/main/java/com/node5/supportservice/search/presentation/SearchInternalController.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/presentation/SearchInternalController.java
@@ -1,0 +1,33 @@
+package com.node5.supportservice.search.presentation;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.node5.supportservice.search.application.SponsoredProductService;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/internal/sponsored-products")
+@RequiredArgsConstructor
+@Hidden
+public class SearchInternalController {
+
+	private final SponsoredProductService sponsoredProductService;
+
+	@PostMapping("/{productId}")
+	public void markAsSponsored(@PathVariable UUID productId) {
+		sponsoredProductService.sponsor(productId);
+	}
+
+	@DeleteMapping("/{productId}")
+	public void unmarkAsSponsored(@PathVariable UUID productId) {
+		sponsoredProductService.unsponsor(productId);
+	}
+}


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #473 

## 📌 개요
- 검색 기능 확장을 대비해 Elasticsearch 쿼리 생성 책임을 QueryBuilder/SortBuilder로 분리하고, 스폰서 상품 노출을 위한 검색/관리 기능을 추가합니다.

## ✨ 작업 내용
- 검색/자동완성 쿼리 생성 로직을 Builder로 분리하여 어댑터 의존도를 낮춘다.
- 스폰서 상품 노출을 위해 isSponsored 기반 스폰서 전용 조회와 내부 토글 API를 제공한다.

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
