### PR TITLE
feat: 정산 연동을 위한 내부 API 추가 및 ShopOwnership Port/Adapter 구조 분리

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/CatalogServiceApplication.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/CatalogServiceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@EnableFeignClients(basePackages = "com.node5.catalogservice.shop.client")
+@EnableFeignClients(basePackages = "com.node5.catalogservice")
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class CatalogServiceApplication {

--- a/catalog-service/src/main/java/com/node5/catalogservice/cart/application/CartCleanupService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/cart/application/CartCleanupService.java
@@ -5,8 +5,8 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.node5.catalogservice.cart.domain.CartRepository;
 import com.node5.catalogservice.cart.domain.CartItemRepository;
+import com.node5.catalogservice.cart.domain.CartRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/catalog-service/src/main/java/com/node5/catalogservice/client/FeignShopOwnershipAdapter.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/client/FeignShopOwnershipAdapter.java
@@ -1,0 +1,29 @@
+package com.node5.catalogservice.client;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.node5.catalogservice.client.exception.ClientErrorCode;
+import com.node5.common.exception.BaseException;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FeignShopOwnershipAdapter implements ShopOwnershipPort {
+
+	private final ShopOwnershipFeignClient feignClient;
+
+	@Override
+	public UUID getOwnerMemberId(UUID shopId) {
+		try {
+			return feignClient.getOwnerMemberId(shopId);
+		} catch (FeignException.NotFound e) {
+			throw new BaseException(ClientErrorCode.SHOP_NOT_FOUND);
+		} catch (FeignException e) {
+			throw new BaseException(ClientErrorCode.SHOP_SERVICE_UNAVAILABLE);
+		}
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/client/ShopOwnershipFeignClient.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/client/ShopOwnershipFeignClient.java
@@ -1,4 +1,4 @@
-package com.node5.catalogservice.shop.client;
+package com.node5.catalogservice.client;
 
 import java.util.UUID;
 
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @FeignClient(name = "member-service")
-public interface ShopOwnershipClient {
+public interface ShopOwnershipFeignClient {
 
 	@GetMapping("/internal/shops/{shopId}/member-id")
 	UUID getOwnerMemberId(@PathVariable("shopId") UUID shopId);

--- a/catalog-service/src/main/java/com/node5/catalogservice/client/ShopOwnershipPort.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/client/ShopOwnershipPort.java
@@ -1,0 +1,7 @@
+package com.node5.catalogservice.client;
+
+import java.util.UUID;
+
+public interface ShopOwnershipPort {
+	UUID getOwnerMemberId(UUID shopId);
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/client/exception/ClientErrorCode.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/client/exception/ClientErrorCode.java
@@ -1,0 +1,18 @@
+package com.node5.catalogservice.client.exception;
+
+import com.node5.common.exception.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ClientErrorCode implements BaseErrorCode {
+
+	SHOP_NOT_FOUND(404, "SHOP_NOT_FOUND", "해당 상점을 찾을 수 없습니다."),
+	SHOP_SERVICE_UNAVAILABLE(503, "SHOP_SERVICE_UNAVAILABLE", "상점 소유자 정보를 조회할 수 없습니다.");
+
+	private final int status;
+	private final String code;
+	private final String message;
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/InventoryStockService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/InventoryStockService.java
@@ -5,16 +5,15 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.node5.catalogservice.client.ShopOwnershipPort;
 import com.node5.catalogservice.inventory.domain.Stock;
 import com.node5.catalogservice.inventory.domain.StockRepository;
 import com.node5.catalogservice.inventory.exception.InventoryErrorCode;
 import com.node5.catalogservice.inventory.presentation.dto.StockResponse;
 import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.domain.ProductRepository;
-import com.node5.catalogservice.shop.client.ShopOwnershipClient;
 import com.node5.common.exception.BaseException;
 
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,7 +22,7 @@ public class InventoryStockService {
 
 	private final StockRepository stockRepository;
 	private final ProductRepository productRepository;
-	private final ShopOwnershipClient shopOwnershipClient;
+	private final ShopOwnershipPort shopOwnershipPort;
 
 	@Transactional
 	public StockResponse updateStockQuantity(UUID memberId, UUID productId, int quantity) {
@@ -50,16 +49,9 @@ public class InventoryStockService {
 		Product product = productRepository.findById(productId)
 			.orElseThrow(() -> new BaseException(InventoryErrorCode.PRODUCT_NOT_FOUND));
 
-		try {
-			UUID ownerMemberId = shopOwnershipClient.getOwnerMemberId(product.getShopId());
-
-			if (!ownerMemberId.equals(memberId)) {
-				throw new BaseException(InventoryErrorCode.SELLER_FORBIDDEN);
-			}
-		} catch (FeignException.NotFound e) {
-			throw new BaseException(InventoryErrorCode.SHOP_NOT_FOUND);
-		} catch (FeignException e) {
-			throw new BaseException(InventoryErrorCode.SHOP_SERVICE_UNAVAILABLE);
+		UUID ownerMemberId = shopOwnershipPort.getOwnerMemberId(product.getShopId());
+		if (!ownerMemberId.equals(memberId)) {
+			throw new BaseException(InventoryErrorCode.SELLER_FORBIDDEN);
 		}
 	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/exception/InventoryErrorCode.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/exception/InventoryErrorCode.java
@@ -20,9 +20,7 @@ public enum InventoryErrorCode implements BaseErrorCode {
 	RESERVATION_ALREADY_RELEASED(409, "RESERVATION_ALREADY_RELEASED", "이미 해제된 예약입니다."),
 
 	PRODUCT_NOT_FOUND(404, "PRODUCT_NOT_FOUND", "상품이 존재하지 않습니다."),
-	SELLER_FORBIDDEN(403, "SELLER_FORBIDDEN", "해당 상품에 대한 권한이 없습니다."),
-	SHOP_NOT_FOUND(404, "SHOP_NOT_FOUND", "상점 정보를 찾을 수 없습니다."),
-	SHOP_SERVICE_UNAVAILABLE(503, "SHOP_SERVICE_UNAVAILABLE", "상점 서비스를 사용할 수 없습니다.");
+	SELLER_FORBIDDEN(403, "SELLER_FORBIDDEN", "해당 상품에 대한 권한이 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductInternalService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductInternalService.java
@@ -56,6 +56,15 @@ public class ProductInternalService {
 	}
 
 	@Transactional(readOnly = true)
+	public List<UUID> getProductIdsByShopIds(List<UUID> shopIds) {
+		if (shopIds == null || shopIds.isEmpty()) {
+			return List.of();
+		}
+		List<UUID> distinctShopIds = shopIds.stream().distinct().toList();
+		return productRepository.findIdsByShopIdIn(distinctShopIds);
+	}
+
+	@Transactional(readOnly = true)
 	public boolean isReviewable(UUID productId) {
 		return productRepository.findByIdAndStatus(productId, ProductStatus.ON_SALE).isPresent();
 	}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductInternalService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductInternalService.java
@@ -1,0 +1,62 @@
+package com.node5.catalogservice.product.application;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.node5.catalogservice.product.domain.Product;
+import com.node5.catalogservice.product.domain.ProductRepository;
+import com.node5.catalogservice.product.domain.ProductStatus;
+import com.node5.catalogservice.product.exception.ProductErrorCode;
+import com.node5.common.exception.BaseException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductInternalService {
+
+	private final ProductRepository productRepository;
+
+	@Transactional(readOnly = true)
+	public Map<UUID, UUID> getShopIdsByProductIds(List<UUID> productIds) {
+
+		if (productIds == null || productIds.isEmpty()) {
+			return Map.of();
+		}
+
+		List<UUID> distinctIds = productIds.stream().distinct().toList();
+		List<Product> products = productRepository.findAllByIdIn(distinctIds);
+
+		if (products.size() != distinctIds.size()) {
+			throw new BaseException(ProductErrorCode.PRODUCT_NOT_FOUND);
+		}
+
+		return products.stream().collect(Collectors.toMap(Product::getId, Product::getShopId));
+	}
+
+	@Transactional(readOnly = true)
+	public List<Product> getProductsByIds(List<UUID> productIds) {
+		if (productIds == null || productIds.isEmpty()) {
+			return List.of();
+		}
+		return productRepository.findAllByIdInAndStatus(productIds, ProductStatus.ON_SALE);
+	}
+
+	@Transactional(readOnly = true)
+	public List<UUID> getOnSaleProductIds(Pageable pageable) {
+		return productRepository.findByStatus(ProductStatus.ON_SALE, pageable)
+			.map(Product::getId)
+			.getContent();
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isReviewable(UUID productId) {
+		return productRepository.findByIdAndStatus(productId, ProductStatus.ON_SALE).isPresent();
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
@@ -1,10 +1,7 @@
 package com.node5.catalogservice.product.application;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -126,48 +123,9 @@ public class ProductService {
 			.map(ProductInfo::from);
 	}
 
-	@Transactional(readOnly = true)
-	public Map<UUID, UUID> getShopIdsByProductIds(List<UUID> productIds) {
-
-		if (productIds == null || productIds.isEmpty()) {
-			return Map.of();
-		}
-
-		List<UUID> distinctIds = productIds.stream().distinct().toList();
-
-		List<Product> products = productRepository.findAllByIdIn(distinctIds);
-
-		if (products.size() != distinctIds.size()) {
-			throw new BaseException(ProductErrorCode.PRODUCT_NOT_FOUND);
-		}
-
-		return products.stream()
-			.collect(Collectors.toMap(Product::getId, Product::getShopId));
-	}
-
-	@Transactional(readOnly = true)
-	public List<Product> getProductsByIds(List<UUID> productIds) {
-		if (productIds == null || productIds.isEmpty()) {
-			return List.of();
-		}
-		return productRepository.findAllByIdInAndStatus(productIds, ProductStatus.ON_SALE);
-	}
-
 	private Product getProductOrThrow(UUID productId) {
 		return productRepository.findById(productId)
 			.orElseThrow(() -> new BaseException(ProductErrorCode.PRODUCT_NOT_FOUND));
-	}
-
-	@Transactional(readOnly = true)
-	public List<UUID> getOnSaleProductIds(Pageable pageable) {
-		return productRepository.findByStatus(ProductStatus.ON_SALE, pageable)
-			.map(Product::getId)
-			.getContent();
-	}
-
-	@Transactional(readOnly = true)
-	public boolean isReviewable(UUID productId) {
-		return productRepository.findByIdAndStatus(productId, ProductStatus.ON_SALE).isPresent();
 	}
 
 	private Product getOnSaleProductOrThrow(UUID productId) {

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.node5.catalogservice.client.ShopOwnershipPort;
 import com.node5.catalogservice.product.application.dto.ProductCommand;
 import com.node5.catalogservice.product.application.dto.ProductInfo;
 import com.node5.catalogservice.product.application.dto.ProductUpdateCommand;
@@ -20,11 +21,9 @@ import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.domain.ProductRepository;
 import com.node5.catalogservice.product.domain.ProductStatus;
 import com.node5.catalogservice.product.exception.ProductErrorCode;
-import com.node5.catalogservice.shop.client.ShopOwnershipClient;
 import com.node5.common.event.ProductDiscontinuedEvent;
 import com.node5.common.exception.BaseException;
 
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -35,7 +34,7 @@ public class ProductService {
 	private final ProductIndexEventPort productIndexEventPort;
 	private final ProductEmbeddingEventPort productEmbeddingEventPort;
 	private final ProductDiscontinuedEventPort productDiscontinuedEventPort;
-	private final ShopOwnershipClient shopOwnershipClient;
+	private final ShopOwnershipPort shopOwnershipPort;
 
 	public Page<ProductInfo> getOnSaleProducts(Pageable pageable) {
 		return productRepository.findByStatus(ProductStatus.ON_SALE, pageable)
@@ -134,16 +133,9 @@ public class ProductService {
 	}
 
 	private void validateShopOwnership(UUID memberId, UUID shopId) {
-		try {
-			UUID ownerMemberId = shopOwnershipClient.getOwnerMemberId(shopId);
-
-			if (!ownerMemberId.equals(memberId)) {
-				throw new BaseException(ProductErrorCode.SHOP_FORBIDDEN);
-			}
-		} catch (FeignException.NotFound e) {
-			throw new BaseException(ProductErrorCode.SHOP_NOT_FOUND);
-		} catch (FeignException e) {
-			throw new BaseException(ProductErrorCode.SHOP_SERVICE_UNAVAILABLE);
+		UUID ownerMemberId = shopOwnershipPort.getOwnerMemberId(shopId);
+		if (!ownerMemberId.equals(memberId)) {
+			throw new BaseException(ProductErrorCode.SHOP_FORBIDDEN);
 		}
 	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductRepository.java
@@ -24,5 +24,7 @@ public interface ProductRepository {
 
 	List<Product> findAllByIdInAndStatus(Collection<UUID> ids, ProductStatus status);
 
+	List<UUID> findIdsByShopIdIn(Collection<UUID> shopIds);
+
 	int discontinueByShopId(UUID shopId);
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/exception/ProductErrorCode.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/exception/ProductErrorCode.java
@@ -9,15 +9,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements BaseErrorCode {
 
+	SHOP_FORBIDDEN(403, "SHOP_FORBIDDEN", "해당 상점에 대한 권한이 없습니다."),
 	PRODUCT_NOT_FOUND(404, "PRODUCT_NOT_FOUND", "상품을 찾을 수 없습니다."),
 	ON_SALE_PRODUCT_NOT_FOUND(404, "ON_SALE_PRODUCT_NOT_FOUND", "판매 중인 상품이 아니거나 존재하지 않습니다."),
-
-	SHOP_NOT_FOUND(404, "SHOP_NOT_FOUND", "상점을 찾을 수 없습니다."),
-	SHOP_FORBIDDEN(403, "SHOP_FORBIDDEN", "해당 상점에 대한 권한이 없습니다."),
-
-	PRODUCT_STATUS_CHANGE_NOT_ALLOWED(409, "PRODUCT_STATUS_CHANGE_NOT_ALLOWED", "판매 중단된 상품은 수정/상태 변경이 불가합니다."),
-
-	SHOP_SERVICE_UNAVAILABLE(503, "SHOP_SERVICE_UNAVAILABLE", "상점 정보를 조회할 수 없습니다. 잠시 후 다시 시도해주세요.");
+	PRODUCT_STATUS_CHANGE_NOT_ALLOWED(409, "PRODUCT_STATUS_CHANGE_NOT_ALLOWED", "판매 중단된 상품은 수정/상태 변경이 불가합니다.");
 
 	private final int status;
 	private final String code;

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductJpaRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductJpaRepository.java
@@ -28,6 +28,9 @@ public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
 
 	List<Product> findByIdInAndStatus(Collection<UUID> ids, ProductStatus status);
 
+	@Query("select p.id from Product p where p.shopId in :shopIds")
+	List<UUID> findIdsByShopIdIn(Collection<UUID> shopIds);
+
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Transactional
 	@Query("""

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductRepositoryAdapter.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductRepositoryAdapter.java
@@ -57,6 +57,11 @@ public class ProductRepositoryAdapter implements ProductRepository {
 	}
 
 	@Override
+	public List<UUID> findIdsByShopIdIn(Collection<UUID> shopIds) {
+		return productJpaRepository.findIdsByShopIdIn(shopIds);
+	}
+
+	@Override
 	public int discontinueByShopId(UUID shopId) {
 		return productJpaRepository.discontinueByShopId(shopId);
 	}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.node5.catalogservice.product.application.ProductService;
+import com.node5.catalogservice.product.application.ProductInternalService;
 import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.presentation.dto.ProductIdsRequest;
 import com.node5.catalogservice.product.presentation.dto.ProductReviewStatusResponse;
@@ -32,11 +32,11 @@ import lombok.RequiredArgsConstructor;
 @Hidden
 public class ProductInternalController {
 
-	private final ProductService productService;
+	private final ProductInternalService productInternalService;
 
 	@PostMapping("/shop-ids")
 	public ResponseEntity<Map<UUID, UUID>> getShopIdsByProductIds(@RequestBody List<UUID> productIds) {
-		return ResponseEntity.ok(productService.getShopIdsByProductIds(productIds));
+		return ResponseEntity.ok(productInternalService.getShopIdsByProductIds(productIds));
 	}
 
 	@PostMapping("/getProductsByIds")
@@ -45,7 +45,7 @@ public class ProductInternalController {
 		@Valid @RequestBody ProductIdsRequest request
 	) {
 		List<UUID> ids = request.productIds();
-		List<Product> products = productService.getProductsByIds(ids);
+		List<Product> products = productInternalService.getProductsByIds(ids);
 
 		Map<UUID, Integer> order = new java.util.HashMap<>();
 		for (int i = 0; i < ids.size(); i++) order.put(ids.get(i), i);
@@ -65,12 +65,12 @@ public class ProductInternalController {
 
 	@GetMapping("/ids")
 	public ResponseEntity<List<UUID>> getProductIds(@ParameterObject Pageable pageable) {
-		return ResponseEntity.ok(productService.getOnSaleProductIds(pageable));
+		return ResponseEntity.ok(productInternalService.getOnSaleProductIds(pageable));
 	}
 
 	@GetMapping("/{productId}/review-status")
 	public ResponseEntity<ProductReviewStatusResponse> canPostReview(@PathVariable UUID productId) {
-		boolean reviewable = productService.isReviewable(productId);
+		boolean reviewable = productInternalService.isReviewable(productId);
 		return ResponseEntity.ok(new ProductReviewStatusResponse(reviewable));
 	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
@@ -68,6 +68,11 @@ public class ProductInternalController {
 		return ResponseEntity.ok(productInternalService.getOnSaleProductIds(pageable));
 	}
 
+	@GetMapping("/getProductIds")
+	public ResponseEntity<List<UUID>> getProductIdsByShopIds(@RequestBody List<UUID> shopIds) {
+		return ResponseEntity.ok(productInternalService.getProductIdsByShopIds(shopIds));
+	}
+
 	@GetMapping("/{productId}/review-status")
 	public ResponseEntity<ProductReviewStatusResponse> canPostReview(@PathVariable UUID productId) {
 		boolean reviewable = productInternalService.isReviewable(productId);

--- a/catalog-service/src/test/java/com/node5/catalogservice/product/application/ProductServiceTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/product/application/ProductServiceTest.java
@@ -14,19 +14,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.node5.catalogservice.client.ShopOwnershipPort;
 import com.node5.catalogservice.product.application.dto.ProductCommand;
 import com.node5.catalogservice.product.application.dto.ProductInfo;
 import com.node5.catalogservice.product.application.dto.ProductUpdateCommand;
+import com.node5.catalogservice.product.application.port.ProductDiscontinuedEventPort;
 import com.node5.catalogservice.product.application.port.ProductEmbeddingEventPort;
 import com.node5.catalogservice.product.application.port.ProductIndexEventPort;
 import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.domain.ProductCategory;
 import com.node5.catalogservice.product.domain.ProductRepository;
 import com.node5.catalogservice.product.domain.ProductStatus;
-import com.node5.common.event.ProductIndexEventType;
 import com.node5.catalogservice.product.exception.ProductErrorCode;
-import com.node5.catalogservice.shop.client.ShopOwnershipClient;
 import com.node5.catalogservice.testsupport.ProductTestFactory;
+import com.node5.common.event.ProductIndexEventType;
 import com.node5.common.exception.BaseException;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,7 +43,10 @@ class ProductServiceTest {
 	private ProductEmbeddingEventPort productEmbeddingEventPort;
 
 	@Mock
-	private ShopOwnershipClient shopOwnershipClient;
+	private ProductDiscontinuedEventPort productDiscontinuedEventPort;
+
+	@Mock
+	private ShopOwnershipPort shopOwnershipPort;
 
 	@InjectMocks
 	private ProductService productService;
@@ -62,7 +66,7 @@ class ProductServiceTest {
 			"thumb.png"
 		);
 
-		given(shopOwnershipClient.getOwnerMemberId(shopId)).willReturn(memberId);
+		given(shopOwnershipPort.getOwnerMemberId(shopId)).willReturn(memberId);
 
 		Product saved = ProductTestFactory.onSale();
 		given(productRepository.save(any(Product.class))).willReturn(saved);
@@ -72,7 +76,7 @@ class ProductServiceTest {
 
 		// then
 		assertThat(result).isNotNull();
-		then(shopOwnershipClient).should().getOwnerMemberId(shopId);
+		then(shopOwnershipPort).should().getOwnerMemberId(shopId);
 		then(productRepository).should().save(any(Product.class));
 
 		then(productIndexEventPort).should().publish(argThat(e ->
@@ -84,6 +88,8 @@ class ProductServiceTest {
 		then(productEmbeddingEventPort).should().publish(argThat(e ->
 			e != null && e.productId().equals(saved.getId())
 		));
+
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
 	}
 
 	@Test
@@ -104,7 +110,7 @@ class ProductServiceTest {
 		);
 
 		given(productRepository.findById(productId)).willReturn(Optional.of(existing));
-		given(shopOwnershipClient.getOwnerMemberId(shopId)).willReturn(memberId);
+		given(shopOwnershipPort.getOwnerMemberId(shopId)).willReturn(memberId);
 		given(productRepository.save(existing)).willReturn(existing);
 
 		// when
@@ -112,6 +118,7 @@ class ProductServiceTest {
 
 		// then
 		assertThat(result).isNotNull();
+		then(shopOwnershipPort).should().getOwnerMemberId(shopId);
 		then(productRepository).should().save(existing);
 
 		then(productIndexEventPort).should().publish(argThat(e ->
@@ -123,6 +130,8 @@ class ProductServiceTest {
 		then(productEmbeddingEventPort).should().publish(argThat(e ->
 			e != null && e.productId().equals(existing.getId())
 		));
+
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
 	}
 
 	@Test
@@ -152,6 +161,8 @@ class ProductServiceTest {
 		then(productRepository).should(never()).save(any());
 		then(productIndexEventPort).shouldHaveNoInteractions();
 		then(productEmbeddingEventPort).shouldHaveNoInteractions();
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
+		then(shopOwnershipPort).shouldHaveNoInteractions();
 	}
 
 	@Test
@@ -169,6 +180,11 @@ class ProductServiceTest {
 		// then
 		assertThat(result).isNotNull();
 		then(productRepository).should().findByIdAndStatus(productId, ProductStatus.ON_SALE);
+
+		then(productIndexEventPort).shouldHaveNoInteractions();
+		then(productEmbeddingEventPort).shouldHaveNoInteractions();
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
+		then(shopOwnershipPort).shouldHaveNoInteractions();
 	}
 
 	private static UUID uuid() {


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #485 

## 📌 개요
- 판매자(Shop Owner) 검증을 Port/Adapter 구조로 분리하고, 정산 서비스 연동을 위한 내부 API를 추가합니다.

## ✨ 작업 내용
- ShopOwnership 외부 통신을 Port/Adapter 구조로 분리
- Product/Inventory 서비스에서 Port 기반으로 권한 검증 처리
- 정산 연동을 위한 내부 API 추가

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
