### PR TITLE
refactor: 상품추천 redis 캐시 도입

### DIFF
--- a/config/config/support-service.yaml
+++ b/config/config/support-service.yaml
@@ -42,6 +42,10 @@ spring:
     listener:
       simple:
         default-requeue-rejected: false
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
   kafka:
     # 1. 공통 설정: 카프카 클러스터 주소
     bootstrap-servers: ${KAFKA_HOST}:9092

--- a/k8s/configmaps/support-service-configmap.yaml
+++ b/k8s/configmaps/support-service-configmap.yaml
@@ -48,6 +48,10 @@ data:
         listener:
           simple:
             default-requeue-rejected: false
+      data:
+        redis:
+          host: ${REDIS_HOST}
+          port: 6379
       kafka:
         bootstrap-servers: ${KAFKA_HOST}:9092
         listener:

--- a/support-service/build.gradle
+++ b/support-service/build.gradle
@@ -32,4 +32,5 @@ dependencies {
     implementation 'org.springframework.ai:spring-ai-core:1.0.0-M6'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/support-service/src/main/java/com/node5/supportservice/config/RedisConfig.java
+++ b/support-service/src/main/java/com/node5/supportservice/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.node5.supportservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/support-service/src/main/java/com/node5/supportservice/recommendation/application/RecommendationService.java
+++ b/support-service/src/main/java/com/node5/supportservice/recommendation/application/RecommendationService.java
@@ -14,16 +14,22 @@ import com.node5.supportservice.recommendation.exception.RecommendationErrorCode
 import com.node5.supportservice.recommendation.exception.RecommendationException;
 import com.node5.supportservice.recommendation.client.openai.EmbeddingClient;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
+import java.time.Duration;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -35,6 +41,8 @@ public class RecommendationService {
 
     private static final int DEFAULT_LIMIT = 5;
     private static final int MAX_LIMIT = 10;
+    private static final Duration RECOMMENDATION_CACHE_TTL = Duration.ofMinutes(30);
+    private static final String CACHE_KEY_PREFIX = "recommendation:taste:";
 
     private final ProductEmbeddingRepository productEmbeddingRepository;
     private final ChatService chatService;
@@ -42,9 +50,15 @@ public class RecommendationService {
     private final ObjectMapper objectMapper;
     private final CatalogClient catalogClient;
     private final OrderClient orderClient;
+    private final StringRedisTemplate stringRedisTemplate;
 
     // 장바구니 아이템 받아서 취향 임베딩 반환
     public Result recommendTaste(UUID memberId, List<UUID> cartItemProductIds) {
+        Result cachedResult = getCachedTaste(memberId, cartItemProductIds);
+        if (cachedResult != null) {
+            return cachedResult;
+        }
+
         // 장바구니 내역
         ProductSummaryListResponse cartItemResponse = getProductInfo(memberId, cartItemProductIds, "장바구니");
         log.info("조회된 장바구니 내역 size: {}", cartItemResponse.products().size());
@@ -66,7 +80,9 @@ public class RecommendationService {
         log.info("** LLM TASTE SUMMARY: {}", tasteSummary);
         log.info("** LLM TASTE EMBEDDING: {}", Arrays.toString(embedding));
 
-        return new Result(tasteSummary, embedding, existedProductIds);
+        Result result = new Result(tasteSummary, embedding, existedProductIds);
+        cacheTaste(memberId, cartItemProductIds, result);
+        return result;
     }
 
     private List<UUID> getExistedProductIds(List<UUID> cartItemProductIds, List<UUID> recentOrderProductIds) {
@@ -172,4 +188,57 @@ public class RecommendationService {
         }
         return limit;
     }
+
+    private Result getCachedTaste(UUID memberId, List<UUID> cartItemProductIds) {
+        String cacheKey = buildCacheKey(memberId, cartItemProductIds);
+        try {
+            String cachedJson = stringRedisTemplate.opsForValue().get(cacheKey);
+            if (cachedJson == null || cachedJson.isBlank()) {
+                return null;
+            }
+            CachedTaste cachedTaste = objectMapper.readValue(cachedJson, CachedTaste.class);
+            return new Result(cachedTaste.tasteSummary(), cachedTaste.embedding(), cachedTaste.existedProductIds());
+        } catch (Exception ex) {
+            log.warn("추천 캐시 조회 실패 (key: {}): {}", cacheKey, ex.getMessage());
+            return null;
+        }
+    }
+
+    private void cacheTaste(UUID memberId, List<UUID> cartItemProductIds, Result result) {
+        String cacheKey = buildCacheKey(memberId, cartItemProductIds);
+        try {
+            CachedTaste cachedTaste = new CachedTaste(result.tasteSummary(), result.embedding(), result.existedProductIds());
+            String cachedJson = objectMapper.writeValueAsString(cachedTaste);
+            stringRedisTemplate.opsForValue().set(cacheKey, cachedJson, RECOMMENDATION_CACHE_TTL);
+        } catch (Exception ex) {
+            log.warn("추천 캐시 저장 실패 (key: {}): {}", cacheKey, ex.getMessage());
+        }
+    }
+
+    private String buildCacheKey(UUID memberId, List<UUID> cartItemProductIds) {
+        List<UUID> sortedIds = new ArrayList<>();
+        if (cartItemProductIds != null) {
+            sortedIds.addAll(cartItemProductIds);
+        }
+        sortedIds.sort(Comparator.comparing(UUID::toString));
+        String rawKey = memberId + ":" + sortedIds;
+        return CACHE_KEY_PREFIX + sha256(rawKey);
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            log.warn("SHA-256 not available. Falling back to raw cache key.");
+            return value;
+        }
+    }
+
+    private record CachedTaste(String tasteSummary, float[] embedding, List<UUID> existedProductIds) {}
 }


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #520 

## 📌 개요
- 상품 추천 시에 토큰 사용량을 줄이기 위해 상품추천목록을 Redis 캐시에 저장하도록 만들었습니다.

## ✨ 작업 내용
- 상품 추천 계산 후 캐시에 저장
- 장바구니 내용을 보고 캐시에 있는 데이터면 캐시에서 반환
- 캐시는 30분 유지됩니다.

## 🧪 테스트 방법
- 로컬 스웨거로 테스트, 로그 확인

## 🔗 참고 사항 : 
- 스크린샷, 참고 문서 등

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
