### PR TITLE
feat: 상품 생성 API에 Idempotency-Key 기반 멱등성 처리 추가

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductService.java
@@ -1,12 +1,14 @@
 package com.node5.catalogservice.product.application;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.node5.catalogservice.client.ShopOwnershipPort;
 import com.node5.catalogservice.product.application.dto.ProductCommand;
@@ -18,6 +20,8 @@ import com.node5.catalogservice.product.application.port.ProductDiscontinuedEven
 import com.node5.catalogservice.product.application.port.ProductEmbeddingEventPort;
 import com.node5.catalogservice.product.application.port.ProductIndexEventPort;
 import com.node5.catalogservice.product.domain.Product;
+import com.node5.catalogservice.product.domain.ProductIdempotency;
+import com.node5.catalogservice.product.domain.ProductIdempotencyRepository;
 import com.node5.catalogservice.product.domain.ProductRepository;
 import com.node5.catalogservice.product.domain.ProductStatus;
 import com.node5.catalogservice.product.exception.ProductErrorCode;
@@ -31,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class ProductService {
 
 	private final ProductRepository productRepository;
+	private final ProductIdempotencyRepository productIdempotencyRepository;
 	private final ProductIndexEventPort productIndexEventPort;
 	private final ProductEmbeddingEventPort productEmbeddingEventPort;
 	private final ProductDiscontinuedEventPort productDiscontinuedEventPort;
@@ -46,23 +51,64 @@ public class ProductService {
 	}
 
 	@Transactional
-	public ProductInfo createProduct(UUID memberId, UUID shopId, ProductCommand command) {
+	public ProductInfo createProduct(UUID memberId, UUID shopId, ProductCommand command, String idempotencyKey) {
 		validateShopOwnership(memberId, shopId);
 
-		Product product = Product.create(
-			shopId,
-			command.name(),
-			command.description(),
-			command.price(),
-			command.status(),
-			command.category(),
-			command.thumbnailKey()
-		);
+		// Idempotency-Key 미포함 요청은 하위 호환을 위해 기존 방식으로 처리
+		if (!StringUtils.hasText(idempotencyKey)) {
+			return createProductInternal(shopId, command);
+		}
 
-		Product saved = productRepository.save(product);
-		productIndexEventPort.publish(ProductIndexEventMapper.forCreate(saved));
-		productEmbeddingEventPort.publish(ProductEmbeddingEventMapper.from(saved));
-		return ProductInfo.from(saved);
+		boolean started = productIdempotencyRepository.tryStartProcessing(idempotencyKey);
+
+		if (!started) {
+			ProductIdempotency existing = productIdempotencyRepository.findByKey(idempotencyKey)
+				.orElseThrow(() -> new BaseException(ProductErrorCode.IDEMPOTENCY_DATA_CORRUPTED));
+
+			return switch (existing.getStatus()) {
+				case COMPLETED -> {
+					UUID productId = existing.getProductId();
+					if (productId == null) {
+						throw new BaseException(ProductErrorCode.IDEMPOTENCY_DATA_CORRUPTED);
+					}
+					Product saved = productRepository.findById(productId)
+						.orElseThrow(() -> new BaseException(ProductErrorCode.IDEMPOTENCY_DATA_CORRUPTED));
+					yield ProductInfo.from(saved);
+				}
+				case PROCESSING -> throw new BaseException(ProductErrorCode.IDEMPOTENCY_REQUEST_IN_PROGRESS);
+				case FAILED -> throw new BaseException(ProductErrorCode.IDEMPOTENCY_PREVIOUSLY_FAILED);
+			};
+		}
+
+		try {
+			Product product = Product.create(
+				shopId,
+				command.name(),
+				command.description(),
+				command.price(),
+				command.status(),
+				command.category(),
+				command.thumbnailKey()
+			);
+
+			Product saved = productRepository.save(product);
+
+			ProductIdempotency idem = productIdempotencyRepository.findByKey(idempotencyKey)
+				.orElseThrow(() -> new BaseException(ProductErrorCode.IDEMPOTENCY_DATA_CORRUPTED));
+			idem.complete(saved.getId());
+			productIdempotencyRepository.save(idem);
+
+			productIndexEventPort.publish(ProductIndexEventMapper.forCreate(saved));
+			productEmbeddingEventPort.publish(ProductEmbeddingEventMapper.from(saved));
+
+			return ProductInfo.from(saved);
+
+		} catch (RuntimeException e) {
+			if (!(e instanceof BaseException)) {
+				markIdempotencyFailed(idempotencyKey);
+			}
+			throw e;
+		}
 	}
 
 	@Transactional
@@ -120,6 +166,33 @@ public class ProductService {
 
 		return productRepository.findByShopId(shopId, pageable)
 			.map(ProductInfo::from);
+	}
+
+	private ProductInfo createProductInternal(UUID shopId, ProductCommand command) {
+		Product product = Product.create(
+			shopId,
+			command.name(),
+			command.description(),
+			command.price(),
+			command.status(),
+			command.category(),
+			command.thumbnailKey()
+		);
+
+		Product saved = productRepository.save(product);
+		productIndexEventPort.publish(ProductIndexEventMapper.forCreate(saved));
+		productEmbeddingEventPort.publish(ProductEmbeddingEventMapper.from(saved));
+		return ProductInfo.from(saved);
+	}
+
+	private void markIdempotencyFailed(String idempotencyKey) {
+		Optional<ProductIdempotency> idemOpt = productIdempotencyRepository.findByKey(idempotencyKey);
+		if (idemOpt.isEmpty()) {
+			return;
+		}
+		ProductIdempotency idempotency = idemOpt.get();
+		idempotency.fail();
+		productIdempotencyRepository.save(idempotency);
 	}
 
 	private Product getProductOrThrow(UUID productId) {

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductIdempotency.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductIdempotency.java
@@ -1,0 +1,55 @@
+package com.node5.catalogservice.product.domain;
+
+import java.util.UUID;
+
+import com.node5.common.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "product_idempotency", schema = "catalog")
+public class ProductIdempotency extends BaseEntity {
+
+	@Id
+	@Column(name = "idempotency_key", length = 80)
+	private String idempotencyKey;
+
+	@Column(name = "product_id")
+	private UUID productId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private Status status;
+
+	protected ProductIdempotency() {
+	}
+
+	private ProductIdempotency(String idempotencyKey) {
+		this.idempotencyKey = idempotencyKey;
+		this.status = Status.PROCESSING;
+	}
+
+	public static ProductIdempotency processing(String key) {
+		return new ProductIdempotency(key);
+	}
+
+	public void complete(UUID productId) {
+		this.productId = productId;
+		this.status = Status.COMPLETED;
+	}
+
+	public void fail() {
+		this.status = Status.FAILED;
+	}
+
+	public enum Status {
+		PROCESSING, COMPLETED, FAILED
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductIdempotencyRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/domain/ProductIdempotencyRepository.java
@@ -1,0 +1,16 @@
+package com.node5.catalogservice.product.domain;
+
+import java.util.Optional;
+
+public interface ProductIdempotencyRepository {
+
+	/**
+	 * key로 PROCESSING 레코드를 선점 시도합니다.
+	 * @return true면 선점 성공, false면 이미 존재
+	 */
+	boolean tryStartProcessing(String idempotencyKey);
+
+	Optional<ProductIdempotency> findByKey(String idempotencyKey);
+
+	ProductIdempotency save(ProductIdempotency entity);
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/exception/ProductErrorCode.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/exception/ProductErrorCode.java
@@ -12,7 +12,11 @@ public enum ProductErrorCode implements BaseErrorCode {
 	SHOP_FORBIDDEN(403, "SHOP_FORBIDDEN", "해당 상점에 대한 권한이 없습니다."),
 	PRODUCT_NOT_FOUND(404, "PRODUCT_NOT_FOUND", "상품을 찾을 수 없습니다."),
 	ON_SALE_PRODUCT_NOT_FOUND(404, "ON_SALE_PRODUCT_NOT_FOUND", "판매 중인 상품이 아니거나 존재하지 않습니다."),
-	PRODUCT_STATUS_CHANGE_NOT_ALLOWED(409, "PRODUCT_STATUS_CHANGE_NOT_ALLOWED", "판매 중단된 상품은 수정/상태 변경이 불가합니다.");
+	PRODUCT_STATUS_CHANGE_NOT_ALLOWED(409, "PRODUCT_STATUS_CHANGE_NOT_ALLOWED", "판매 중단된 상품은 수정/상태 변경이 불가합니다."),
+
+	IDEMPOTENCY_REQUEST_IN_PROGRESS(409, "IDEMPOTENCY_REQUEST_IN_PROGRESS", "동일한 요청이 처리 중입니다. 같은 Idempotency-Key로 잠시 후 다시 시도해주세요."),
+	IDEMPOTENCY_PREVIOUSLY_FAILED(409, "IDEMPOTENCY_PREVIOUSLY_FAILED", "이전 동일 요청이 실패했습니다. 새로운 요청으로 다시 시도해주세요."),
+	IDEMPOTENCY_DATA_CORRUPTED(500, "IDEMPOTENCY_DATA_CORRUPTED", "멱등성 데이터가 손상되었습니다. 관리자에게 문의하세요.");
 
 	private final int status;
 	private final String code;

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductIdempotencyJpaRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductIdempotencyJpaRepository.java
@@ -1,0 +1,19 @@
+package com.node5.catalogservice.product.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.node5.catalogservice.product.domain.ProductIdempotency;
+
+public interface ProductIdempotencyJpaRepository extends JpaRepository<ProductIdempotency, String> {
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query(value = """
+		INSERT INTO catalog.product_idempotency (idempotency_key, status)
+		VALUES (:key, 'PROCESSING')
+		ON CONFLICT (idempotency_key) DO NOTHING
+		""", nativeQuery = true)
+	int tryInsertProcessing(@Param("key") String key);
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductIdempotencyRepositoryAdapter.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/infrastructure/ProductIdempotencyRepositoryAdapter.java
@@ -1,0 +1,36 @@
+package com.node5.catalogservice.product.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.node5.catalogservice.product.domain.ProductIdempotency;
+import com.node5.catalogservice.product.domain.ProductIdempotencyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductIdempotencyRepositoryAdapter implements ProductIdempotencyRepository {
+
+	private final ProductIdempotencyJpaRepository jpaRepository;
+
+	@Override
+	@Transactional
+	public boolean tryStartProcessing(String idempotencyKey) {
+		return jpaRepository.tryInsertProcessing(idempotencyKey) == 1;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<ProductIdempotency> findByKey(String idempotencyKey) {
+		return jpaRepository.findById(idempotencyKey);
+	}
+
+	@Override
+	@Transactional
+	public ProductIdempotency save(ProductIdempotency entity) {
+		return jpaRepository.save(entity);
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/SellerProductController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/SellerProductController.java
@@ -74,11 +74,12 @@ public class SellerProductController {
 	})
 	public ResponseEntity<ProductInfo> createProduct(
 		@RequestHeader("Member-Id") UUID memberId,
+		@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
 		@PathVariable("shopId") UUID shopId,
 		@Valid @RequestBody ProductRequest request
 	) {
 		ProductCommand command = request.toCommand();
-		ProductInfo created = productService.createProduct(memberId, shopId, command);
+		ProductInfo created = productService.createProduct(memberId, shopId, command, idempotencyKey);
 		return ResponseEntity.status(HttpStatus.CREATED).body(created);
 	}
 

--- a/catalog-service/src/test/java/com/node5/catalogservice/product/application/ProductServiceTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/product/application/ProductServiceTest.java
@@ -23,6 +23,8 @@ import com.node5.catalogservice.product.application.port.ProductEmbeddingEventPo
 import com.node5.catalogservice.product.application.port.ProductIndexEventPort;
 import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.domain.ProductCategory;
+import com.node5.catalogservice.product.domain.ProductIdempotency;
+import com.node5.catalogservice.product.domain.ProductIdempotencyRepository;
 import com.node5.catalogservice.product.domain.ProductRepository;
 import com.node5.catalogservice.product.domain.ProductStatus;
 import com.node5.catalogservice.product.exception.ProductErrorCode;
@@ -35,6 +37,9 @@ class ProductServiceTest {
 
 	@Mock
 	private ProductRepository productRepository;
+
+	@Mock
+	private ProductIdempotencyRepository productIdempotencyRepository;
 
 	@Mock
 	private ProductIndexEventPort productIndexEventPort;
@@ -52,7 +57,7 @@ class ProductServiceTest {
 	private ProductService productService;
 
 	@Test
-	void 상품_생성_성공시_소유권검증후_저장하고_색인과_임베딩_이벤트를_발행한다() {
+	void 상품_생성_키없음_성공시_소유권검증후_저장하고_색인과_임베딩_이벤트를_발행한다() {
 		// given
 		UUID memberId = uuid();
 		UUID shopId = uuid();
@@ -71,13 +76,15 @@ class ProductServiceTest {
 		Product saved = ProductTestFactory.onSale();
 		given(productRepository.save(any(Product.class))).willReturn(saved);
 
-		// when
-		ProductInfo result = productService.createProduct(memberId, shopId, command);
+		// when (idempotencyKey 없음)
+		ProductInfo result = productService.createProduct(memberId, shopId, command, null);
 
 		// then
 		assertThat(result).isNotNull();
 		then(shopOwnershipPort).should().getOwnerMemberId(shopId);
 		then(productRepository).should().save(any(Product.class));
+
+		then(productIdempotencyRepository).shouldHaveNoInteractions();
 
 		then(productIndexEventPort).should().publish(argThat(e ->
 			e != null
@@ -89,6 +96,137 @@ class ProductServiceTest {
 			e != null && e.productId().equals(saved.getId())
 		));
 
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
+	}
+
+	@Test
+	void 상품_생성_키있음_최초요청이면_PROCESSING선점후_상품을생성하고_idempotency를_COMPLETED로_업데이트한다() {
+		// given
+		UUID memberId = uuid();
+		UUID shopId = uuid();
+		String idempotencyKey = "idem-001";
+
+		ProductCommand command = new ProductCommand(
+			"name",
+			"desc",
+			BigDecimal.valueOf(1000),
+			ProductStatus.ON_SALE,
+			anyCategory(),
+			"thumb.png"
+		);
+
+		given(shopOwnershipPort.getOwnerMemberId(shopId)).willReturn(memberId);
+
+		given(productIdempotencyRepository.tryStartProcessing(idempotencyKey)).willReturn(true);
+
+		ProductIdempotency processing = ProductIdempotency.processing(idempotencyKey);
+		given(productIdempotencyRepository.findByKey(idempotencyKey)).willReturn(Optional.of(processing));
+
+		Product saved = ProductTestFactory.onSale();
+		given(productRepository.save(any(Product.class))).willReturn(saved);
+
+		// when
+		ProductInfo result = productService.createProduct(memberId, shopId, command, idempotencyKey);
+
+		// then
+		assertThat(result).isNotNull();
+
+		then(productIdempotencyRepository).should().tryStartProcessing(idempotencyKey);
+		then(productRepository).should().save(any(Product.class));
+
+		then(productIdempotencyRepository).should().save(argThat(idem ->
+			idem != null
+				&& idem.getIdempotencyKey().equals(idempotencyKey)
+				&& idem.getStatus() == ProductIdempotency.Status.COMPLETED
+				&& saved.getId().equals(idem.getProductId())
+		));
+
+		then(productIndexEventPort).should().publish(argThat(e ->
+			e != null
+				&& e.productId().equals(saved.getId())
+				&& e.type() == ProductIndexEventType.CREATE
+		));
+
+		then(productEmbeddingEventPort).should().publish(argThat(e ->
+			e != null && e.productId().equals(saved.getId())
+		));
+
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
+	}
+
+	@Test
+	void 상품_생성_키있음_이미_COMPLETED면_기존상품을_반환하고_이벤트는_발행하지않는다() {
+		// given
+		UUID memberId = uuid();
+		UUID shopId = uuid();
+		String idempotencyKey = "idem-002";
+
+		ProductCommand command = new ProductCommand(
+			"name",
+			"desc",
+			BigDecimal.valueOf(1000),
+			ProductStatus.ON_SALE,
+			anyCategory(),
+			"thumb.png"
+		);
+
+		given(shopOwnershipPort.getOwnerMemberId(shopId)).willReturn(memberId);
+
+		given(productIdempotencyRepository.tryStartProcessing(idempotencyKey)).willReturn(false);
+
+		Product existingProduct = ProductTestFactory.onSale();
+		ProductIdempotency completed = ProductIdempotency.processing(idempotencyKey);
+		completed.complete(existingProduct.getId());
+
+		given(productIdempotencyRepository.findByKey(idempotencyKey)).willReturn(Optional.of(completed));
+		given(productRepository.findById(existingProduct.getId())).willReturn(Optional.of(existingProduct));
+
+		// when
+		ProductInfo result = productService.createProduct(memberId, shopId, command, idempotencyKey);
+
+		// then
+		assertThat(result).isNotNull();
+
+		then(productRepository).should(never()).save(any(Product.class));
+		then(productIndexEventPort).shouldHaveNoInteractions();
+		then(productEmbeddingEventPort).shouldHaveNoInteractions();
+		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
+	}
+
+	@Test
+	void 상품_생성_키있음_PROCESSING이면_409_IDEMPOTENCY_REQUEST_IN_PROGRESS() {
+		// given
+		UUID memberId = uuid();
+		UUID shopId = uuid();
+		String idempotencyKey = "idem-003";
+
+		ProductCommand command = new ProductCommand(
+			"name",
+			"desc",
+			BigDecimal.valueOf(1000),
+			ProductStatus.ON_SALE,
+			anyCategory(),
+			"thumb.png"
+		);
+
+		given(shopOwnershipPort.getOwnerMemberId(shopId)).willReturn(memberId);
+
+		given(productIdempotencyRepository.tryStartProcessing(idempotencyKey)).willReturn(false);
+
+		ProductIdempotency processing = ProductIdempotency.processing(idempotencyKey);
+		given(productIdempotencyRepository.findByKey(idempotencyKey)).willReturn(Optional.of(processing));
+
+		// when & then
+		assertThatThrownBy(() -> productService.createProduct(memberId, shopId, command, idempotencyKey))
+			.isInstanceOf(BaseException.class)
+			.satisfies(ex -> {
+				BaseException be = (BaseException) ex;
+				assertThat(be.getErrorCode()).isEqualTo(ProductErrorCode.IDEMPOTENCY_REQUEST_IN_PROGRESS);
+			});
+
+		then(productRepository).should(never()).save(any(Product.class));
+		then(productIndexEventPort).shouldHaveNoInteractions();
+		then(productEmbeddingEventPort).shouldHaveNoInteractions();
 		then(productDiscontinuedEventPort).shouldHaveNoInteractions();
 	}
 

--- a/docs/ddl/catalog-ddl.sql
+++ b/docs/ddl/catalog-ddl.sql
@@ -64,6 +64,16 @@ CREATE TABLE catalog.stock_reservation (
     CONSTRAINT uq_stock_reservation UNIQUE (order_id, product_id)
 );
 
+CREATE TABLE catalog.product_idempotency (
+    idempotency_key varchar(80) NOT NULL,
+    product_id uuid NULL,
+    status varchar(20) NOT NULL,
+    created_at timestamp(6) NOT NULL DEFAULT now(),
+    modified_at timestamp(6) NOT NULL DEFAULT now(),
+    CONSTRAINT pk_product_idempotency PRIMARY KEY (idempotency_key),
+    CONSTRAINT ck_product_idempotency_status CHECK (status IN ('PROCESSING', 'COMPLETED', 'FAILED'))
+);
+
 CREATE INDEX ix_stock_reservation_product_status
     ON catalog.stock_reservation (product_id, status);
 


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #527 

## 📌 개요
- 상품 생성 API에 Idempotency-Key 기반 멱등성 처리를 추가하여 네트워크 재시도나 중복 요청으로 인해 동일 상품이 여러 번 생성되는 문제를 방지합니다.

## ✨ 작업 내용
- 상품 생성 시 Idempotency-Key 선점 및 상태(PROCESSING / COMPLETED / FAILED) 관리
- 멱등성 시나리오(최초 요청, 중복 요청, 처리 중 요청)에 대한 테스트 추가

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
