### PR TITLE
feat: 검색 재색인 및 상태 조회 API 추가

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductInternalService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/application/ProductInternalService.java
@@ -1,5 +1,6 @@
 package com.node5.catalogservice.product.application;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -13,6 +14,8 @@ import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.domain.ProductRepository;
 import com.node5.catalogservice.product.domain.ProductStatus;
 import com.node5.catalogservice.product.exception.ProductErrorCode;
+import com.node5.catalogservice.product.presentation.dto.ProductIndexSummaryListResponse;
+import com.node5.catalogservice.product.presentation.dto.ProductIndexSummaryResponse;
 import com.node5.common.exception.BaseException;
 
 import lombok.RequiredArgsConstructor;
@@ -67,5 +70,46 @@ public class ProductInternalService {
 	@Transactional(readOnly = true)
 	public boolean isReviewable(UUID productId) {
 		return productRepository.findByIdAndStatus(productId, ProductStatus.ON_SALE).isPresent();
+	}
+
+
+	@Transactional(readOnly = true)
+	public ProductIndexSummaryListResponse getProductIndexSummaries(List<UUID> productIds) {
+		if (productIds == null || productIds.isEmpty()) {
+			return new ProductIndexSummaryListResponse(List.of());
+		}
+
+		Map<UUID, Integer> order = new HashMap<>();
+		for (int i = 0; i < productIds.size(); i++) order.put(productIds.get(i), i);
+
+		List<UUID> distinctIds = productIds.stream().distinct().toList();
+		List<Product> products = productRepository.findAllByIdInAndStatus(distinctIds, ProductStatus.ON_SALE);
+
+		List<ProductIndexSummaryResponse> summaries = products.stream()
+			.map(p -> new ProductIndexSummaryResponse(
+				p.getId(),
+				p.getShopId(),
+				p.getName(),
+				buildNameAutocomplete(p.getName()),
+				p.getCategory().name(),
+				p.getThumbnailKey(),
+				toLongPrice(p.getPrice()),
+				p.getStatus().name(),
+				p.getCreatedAt(),
+				p.getModifiedAt()
+			))
+			.sorted(java.util.Comparator.comparingInt(s -> order.getOrDefault(s.productId(), Integer.MAX_VALUE)))
+			.toList();
+
+		return new ProductIndexSummaryListResponse(summaries);
+	}
+
+	private String buildNameAutocomplete(String name) {
+		return name;
+	}
+
+	private long toLongPrice(java.math.BigDecimal price) {
+		if (price == null) return 0L;
+		return price.longValue();
 	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/ProductInternalController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.node5.catalogservice.product.application.ProductInternalService;
 import com.node5.catalogservice.product.domain.Product;
 import com.node5.catalogservice.product.presentation.dto.ProductIdsRequest;
+import com.node5.catalogservice.product.presentation.dto.ProductIndexSummaryListResponse;
 import com.node5.catalogservice.product.presentation.dto.ProductReviewStatusResponse;
 import com.node5.catalogservice.product.presentation.dto.ProductSummaryListResponse;
 import com.node5.catalogservice.product.presentation.dto.ProductSummaryResponse;
@@ -77,5 +78,12 @@ public class ProductInternalController {
 	public ResponseEntity<ProductReviewStatusResponse> canPostReview(@PathVariable UUID productId) {
 		boolean reviewable = productInternalService.isReviewable(productId);
 		return ResponseEntity.ok(new ProductReviewStatusResponse(reviewable));
+	}
+
+	@PostMapping("/summaries")
+	public ResponseEntity<ProductIndexSummaryListResponse> getProductIndexSummaries(
+		@Valid @RequestBody ProductIdsRequest request
+	) {
+		return ResponseEntity.ok(productInternalService.getProductIndexSummaries(request.productIds()));
 	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/dto/ProductIndexSummaryListResponse.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/dto/ProductIndexSummaryListResponse.java
@@ -1,0 +1,8 @@
+package com.node5.catalogservice.product.presentation.dto;
+
+import java.util.List;
+
+public record ProductIndexSummaryListResponse(
+	List<ProductIndexSummaryResponse> products
+) {
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/dto/ProductIndexSummaryResponse.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/product/presentation/dto/ProductIndexSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.node5.catalogservice.product.presentation.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ProductIndexSummaryResponse(
+	UUID productId,
+	UUID shopId,
+	String name,
+	String nameAutocomplete,
+	String category,
+	String thumbnailKey,
+	long price,
+	String status,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt
+) {
+}

--- a/config/config/support-service.yaml
+++ b/config/config/support-service.yaml
@@ -97,3 +97,5 @@ app:
   search:
     index:
       product: products
+    reindex:
+      page-size: 500

--- a/support-service/src/main/java/com/node5/supportservice/config/SearchConfig.java
+++ b/support-service/src/main/java/com/node5/supportservice/config/SearchConfig.java
@@ -5,8 +5,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(SearchIndexProperties.class)
-public class SearchIndexNameConfig {
+@EnableConfigurationProperties({
+	SearchIndexProperties.class,
+	SearchReindexProperties.class
+})
+public class SearchConfig {
 
 	@Bean(name = "productIndexName")
 	public String productIndexName(SearchIndexProperties props) {

--- a/support-service/src/main/java/com/node5/supportservice/config/SearchReindexProperties.java
+++ b/support-service/src/main/java/com/node5/supportservice/config/SearchReindexProperties.java
@@ -1,0 +1,13 @@
+package com.node5.supportservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.search.reindex")
+public class SearchReindexProperties {
+	private int pageSize = 500;
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ProductReindexService.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ProductReindexService.java
@@ -1,0 +1,135 @@
+package com.node5.supportservice.search.application.reindex;
+
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.node5.common.exception.BaseException;
+import com.node5.supportservice.config.SearchReindexProperties;
+import com.node5.supportservice.search.exception.SearchErrorCode;
+import com.node5.supportservice.search.infrastructure.client.CatalogInternalFeignClient;
+import com.node5.supportservice.search.infrastructure.client.dto.ProductIdsRequest;
+import com.node5.supportservice.search.infrastructure.client.dto.ProductIndexSummaryListResponse;
+import com.node5.supportservice.search.infrastructure.client.dto.ProductIndexSummaryResponse;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Conflicts;
+
+@Service
+public class ProductReindexService {
+
+	private static final DateTimeFormatter ES_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+	private final ElasticsearchOperations elasticsearchOperations;
+	private final ElasticsearchClient elasticsearchClient;
+	private final CatalogInternalFeignClient feignClient;
+	private final ReindexStatusStore statusStore;
+	private final SearchReindexProperties reindexProps;
+	private final String productIndexName;
+
+	public ProductReindexService(
+		ElasticsearchOperations elasticsearchOperations,
+		ElasticsearchClient elasticsearchClient,
+		CatalogInternalFeignClient feignClient,
+		ReindexStatusStore statusStore,
+		SearchReindexProperties reindexProps,
+		@Qualifier("productIndexName") String productIndexName
+	) {
+		this.elasticsearchOperations = elasticsearchOperations;
+		this.elasticsearchClient = elasticsearchClient;
+		this.feignClient = feignClient;
+		this.statusStore = statusStore;
+		this.reindexProps = reindexProps;
+		this.productIndexName = productIndexName;
+	}
+
+	public void reindexAll() {
+		if (!statusStore.tryStart()) {
+			return;
+		}
+
+		IndexCoordinates index = IndexCoordinates.of(productIndexName);
+
+		try {
+			deleteAllDocsKeepIndex(productIndexName);
+			elasticsearchOperations.indexOps(index).refresh();
+
+			int page = 0;
+			int pageSize = reindexProps.getPageSize();
+
+			while (true) {
+				List<UUID> productIds = feignClient.getOnSaleProductIds(page, pageSize);
+				if (productIds == null || productIds.isEmpty()) {
+					break;
+				}
+
+				ProductIndexSummaryListResponse res =
+					feignClient.getProductSummaries(new ProductIdsRequest(productIds));
+
+				List<ProductIndexSummaryResponse> products =
+					(res == null || res.products() == null) ? List.of() : res.products();
+
+				if (products.isEmpty()) {
+					page++;
+					continue;
+				}
+
+				List<IndexQuery> queries = products.stream()
+					.map(this::toIndexQuery)
+					.toList();
+
+				elasticsearchOperations.bulkIndex(queries, index);
+
+				statusStore.addProcessed(products.size());
+				page++;
+			}
+
+			elasticsearchOperations.indexOps(index).refresh();
+
+			statusStore.markSuccess();
+
+		} catch (Exception e) {
+			statusStore.markFailed(e);
+			throw new BaseException(SearchErrorCode.REINDEX_FAILED);
+		}
+	}
+
+	private void deleteAllDocsKeepIndex(String indexName) throws Exception {
+		elasticsearchClient.deleteByQuery(d -> d
+			.index(indexName)
+			.query(q -> q.matchAll(m -> m))
+			.conflicts(Conflicts.Proceed)
+		);
+	}
+
+	private IndexQuery toIndexQuery(ProductIndexSummaryResponse p) {
+		Map<String, Object> doc = new HashMap<>();
+		doc.put("productId", p.productId().toString());
+		doc.put("shopId", p.shopId().toString());
+		doc.put("name", p.name());
+		doc.put("name_autocomplete",
+			StringUtils.hasText(p.nameAutocomplete()) ? p.nameAutocomplete() : p.name());
+		doc.put("category", p.category());
+		doc.put("thumbnailKey", p.thumbnailKey());
+		doc.put("price", p.price());
+		doc.put("status", p.status());
+		doc.put("createdAt", p.createdAt().format(ES_DATE_TIME));
+		doc.put("modifiedAt", p.modifiedAt().format(ES_DATE_TIME));
+		doc.put("isSponsored", false); // 정책으로 재색인 시 false
+
+		return new IndexQueryBuilder()
+			.withId(p.productId().toString())
+			.withObject(doc)
+			.build();
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ReindexState.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ReindexState.java
@@ -1,0 +1,8 @@
+package com.node5.supportservice.search.application.reindex;
+
+public enum ReindexState {
+	IDLE,
+	RUNNING,
+	SUCCESS,
+	FAILED
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ReindexStatus.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ReindexStatus.java
@@ -1,0 +1,12 @@
+package com.node5.supportservice.search.application.reindex;
+
+import java.time.LocalDateTime;
+
+public record ReindexStatus(
+	ReindexState state,
+	LocalDateTime startedAt,
+	LocalDateTime finishedAt,
+	long processedCount,
+	String lastError
+) {
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ReindexStatusStore.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/application/reindex/ReindexStatusStore.java
@@ -1,0 +1,60 @@
+package com.node5.supportservice.search.application.reindex;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReindexStatusStore {
+
+	private final AtomicReference<ReindexState> state = new AtomicReference<>(ReindexState.IDLE);
+	private final AtomicReference<LocalDateTime> startedAt = new AtomicReference<>(null);
+	private final AtomicReference<LocalDateTime> finishedAt = new AtomicReference<>(null);
+	private final AtomicLong processed = new AtomicLong(0);
+	private final AtomicReference<String> lastError = new AtomicReference<>(null);
+
+	public ReindexStatus snapshot() {
+		return new ReindexStatus(
+			state.get(),
+			startedAt.get(),
+			finishedAt.get(),
+			processed.get(),
+			lastError.get()
+		);
+	}
+
+	public boolean tryStart() {
+		boolean ok = state.compareAndSet(ReindexState.IDLE, ReindexState.RUNNING)
+			|| state.compareAndSet(ReindexState.SUCCESS, ReindexState.RUNNING)
+			|| state.compareAndSet(ReindexState.FAILED, ReindexState.RUNNING);
+
+		if (ok) {
+			startedAt.set(LocalDateTime.now());
+			finishedAt.set(null);
+			processed.set(0);
+			lastError.set(null);
+		}
+		return ok;
+	}
+
+	public void addProcessed(long delta) {
+		processed.addAndGet(delta);
+	}
+
+	public void markSuccess() {
+		state.set(ReindexState.SUCCESS);
+		finishedAt.set(LocalDateTime.now());
+	}
+
+	public void markFailed(Exception e) {
+		state.set(ReindexState.FAILED);
+		finishedAt.set(LocalDateTime.now());
+		lastError.set(e.getClass().getSimpleName() + ": " + e.getMessage());
+	}
+
+	public boolean isRunning() {
+		return state.get() == ReindexState.RUNNING;
+	}
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/domain/ProductDocument.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/domain/ProductDocument.java
@@ -1,7 +1,5 @@
 package com.node5.supportservice.search.domain;
 
-import java.time.LocalDateTime;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;

--- a/support-service/src/main/java/com/node5/supportservice/search/exception/SearchErrorCode.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/exception/SearchErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum SearchErrorCode implements BaseErrorCode {
 
 	INVALID_PRICE_RANGE(400, "SEARCH_INVALID_PRICE_RANGE", "가격 범위가 올바르지 않습니다."),
-	PRICE_RANGE_INCOMPLETE(400, "SEARCH_PRICE_RANGE_INCOMPLETE", "최소/최대 가격은 함께 입력해야 합니다.");
+	PRICE_RANGE_INCOMPLETE(400, "SEARCH_PRICE_RANGE_INCOMPLETE", "최소/최대 가격은 함께 입력해야 합니다."),
+	REINDEX_FAILED(500, "SEARCH_REINDEX_FAILED", "상품 재색인에 실패했습니다.");
 
 	private final int status;
 	private final String code;

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/CatalogInternalFeignClient.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/CatalogInternalFeignClient.java
@@ -1,0 +1,23 @@
+package com.node5.supportservice.search.infrastructure.client;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.node5.supportservice.search.infrastructure.client.dto.ProductIdsRequest;
+import com.node5.supportservice.search.infrastructure.client.dto.ProductIndexSummaryListResponse;
+
+@FeignClient(name = "catalog-service", path = "/internal/products")
+public interface CatalogInternalFeignClient {
+
+	@GetMapping("/ids")
+	List<UUID> getOnSaleProductIds(@RequestParam("page") int page, @RequestParam("size") int size);
+
+	@PostMapping("/summaries")
+	ProductIndexSummaryListResponse getProductSummaries(@RequestBody ProductIdsRequest request);
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/dto/ProductIdsRequest.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/dto/ProductIdsRequest.java
@@ -1,0 +1,7 @@
+package com.node5.supportservice.search.infrastructure.client.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ProductIdsRequest(List<UUID> productIds) {
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/dto/ProductIndexSummaryListResponse.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/dto/ProductIndexSummaryListResponse.java
@@ -1,0 +1,8 @@
+package com.node5.supportservice.search.infrastructure.client.dto;
+
+import java.util.List;
+
+public record ProductIndexSummaryListResponse(
+	List<ProductIndexSummaryResponse> products
+) {
+}

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/dto/ProductIndexSummaryResponse.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/client/dto/ProductIndexSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.node5.supportservice.search.infrastructure.client.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ProductIndexSummaryResponse(
+	UUID productId,
+	UUID shopId,
+	String name,
+	String nameAutocomplete,
+	String category,
+	String thumbnailKey,
+	long price,
+	String status,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt
+) {
+}
+

--- a/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/infrastructure/kafka/KafkaProductIndexEventConsumer.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class KafkaProductIndexEventConsumer {
 
-	DateTimeFormatter ES_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+	private static final DateTimeFormatter ES_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
 	private final ElasticsearchOperations elasticsearchOperations;
 

--- a/support-service/src/main/java/com/node5/supportservice/search/presentation/SearchReindexInternalController.java
+++ b/support-service/src/main/java/com/node5/supportservice/search/presentation/SearchReindexInternalController.java
@@ -1,0 +1,33 @@
+package com.node5.supportservice.search.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.node5.supportservice.search.application.reindex.ProductReindexService;
+import com.node5.supportservice.search.application.reindex.ReindexStatus;
+import com.node5.supportservice.search.application.reindex.ReindexStatusStore;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/internal/search/reindex")
+@RequiredArgsConstructor
+@Hidden
+public class SearchReindexInternalController {
+
+	private final ProductReindexService reindexService;
+	private final ReindexStatusStore statusStore;
+
+	@PostMapping("/products")
+	public void reindexProducts() {
+		reindexService.reindexAll();
+	}
+
+	@GetMapping("/products")
+	public ReindexStatus status() {
+		return statusStore.snapshot();
+	}
+}


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #553 

## 📌 개요
- 검색 인덱스 전체를 다시 생성할 수 있는 상품 재색인(Reindex) 기능을 추가합니다.

## ✨ 작업 내용
- Catalog 서비스 내부 API를 통해 재색인 대상 상품 조회
- Elasticsearch Bulk Index 기반 재색인 로직 구현
- 재색인 상태(RUNNING / SUCCESS / FAILED) 관리

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
