### PR TITLE
feat: 결제 환불에 따른 재고 복원 비동기 처리 구현

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/InventoryRestoreService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/InventoryRestoreService.java
@@ -1,0 +1,61 @@
+package com.node5.catalogservice.inventory.application;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.node5.catalogservice.inventory.application.dto.StockRestoreBatchCommand;
+import com.node5.catalogservice.inventory.domain.ProcessedEventRepository;
+import com.node5.catalogservice.inventory.domain.ProcessedEventType;
+import com.node5.catalogservice.inventory.domain.StockRepository;
+import com.node5.catalogservice.inventory.exception.InventoryErrorCode;
+import com.node5.common.exception.BaseException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryRestoreService {
+
+	private final StockRepository stockRepository;
+	private final ProcessedEventRepository processedEventRepository;
+
+	@Transactional
+	public void restoreBatch(StockRestoreBatchCommand command) {
+
+		if (command == null || command.orderId() == null || command.cancelEventId() == null
+			|| command.items() == null || command.items().isEmpty()) {
+			throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
+		}
+
+		Map<UUID, Integer> merged = new LinkedHashMap<>();
+		for (var item : command.items()) {
+			if (item == null || item.productId() == null || item.quantity() <= 0) {
+				throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
+			}
+			merged.merge(item.productId(), item.quantity(), Integer::sum);
+		}
+
+		boolean firstTime = processedEventRepository.tryInsert(
+			ProcessedEventType.STOCK_RESTORE,
+			command.cancelEventId()
+		);
+
+		if (!firstTime) {
+			return;
+		}
+
+		for (var entry : merged.entrySet()) {
+			UUID productId = entry.getKey();
+			int quantity = entry.getValue();
+
+			int restored = stockRepository.increase(productId, quantity);
+			if (restored == 0) {
+				throw new BaseException(InventoryErrorCode.INVENTORY_NOT_FOUND);
+			}
+		}
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/dto/StockRestoreBatchCommand.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/dto/StockRestoreBatchCommand.java
@@ -1,0 +1,11 @@
+package com.node5.catalogservice.inventory.application.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record StockRestoreBatchCommand(
+	UUID orderId,
+	UUID cancelEventId,
+	List<StockRestoreItemCommand> items
+) {
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/dto/StockRestoreItemCommand.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/dto/StockRestoreItemCommand.java
@@ -1,0 +1,9 @@
+package com.node5.catalogservice.inventory.application.dto;
+
+import java.util.UUID;
+
+public record StockRestoreItemCommand(
+	UUID productId,
+	int quantity
+) {
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEvent.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEvent.java
@@ -1,0 +1,33 @@
+package com.node5.catalogservice.inventory.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "processed_event", schema = "catalog")
+public class ProcessedEvent {
+
+	@EmbeddedId
+	private ProcessedEventId id;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	private ProcessedEvent(ProcessedEventId id) {
+		this.id = id;
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public static ProcessedEvent of(ProcessedEventType type, UUID eventId) {
+		return new ProcessedEvent(new ProcessedEventId(type.name(), eventId));
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEventId.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEventId.java
@@ -1,0 +1,28 @@
+package com.node5.catalogservice.inventory.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode
+@Embeddable
+public class ProcessedEventId implements Serializable {
+
+	@Column(name = "event_type", length = 50, nullable = false)
+	private String eventType;
+
+	@Column(name = "event_id", nullable = false)
+	private UUID eventId;
+
+	public ProcessedEventId(String eventType, UUID eventId) {
+		this.eventType = eventType;
+		this.eventId = eventId;
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEventRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEventRepository.java
@@ -1,0 +1,13 @@
+package com.node5.catalogservice.inventory.domain;
+
+import java.util.UUID;
+
+public interface ProcessedEventRepository {
+
+	/**
+	 * 멱등 처리를 위해 이벤트 처리 여부를 기록합니다.
+	 *
+	 * @return true면 최초 처리(삽입 성공), false면 이미 처리됨(중복)
+	 */
+	boolean tryInsert(ProcessedEventType eventType, UUID eventId);
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEventType.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/ProcessedEventType.java
@@ -1,0 +1,5 @@
+package com.node5.catalogservice.inventory.domain;
+
+public enum ProcessedEventType {
+	STOCK_RESTORE
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/infrastructure/ProcessedEventJpaRepository.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/infrastructure/ProcessedEventJpaRepository.java
@@ -1,0 +1,25 @@
+package com.node5.catalogservice.inventory.infrastructure;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.node5.catalogservice.inventory.domain.ProcessedEvent;
+import com.node5.catalogservice.inventory.domain.ProcessedEventId;
+
+public interface ProcessedEventJpaRepository extends JpaRepository<ProcessedEvent, ProcessedEventId> {
+
+	@Modifying
+	@Query(value = """
+        INSERT INTO catalog.processed_event (event_type, event_id, created_at)
+        VALUES (:eventType, :eventId, now())
+        ON CONFLICT (event_type, event_id) DO NOTHING
+        """, nativeQuery = true)
+	int tryInsert(
+		@Param("eventType") String eventType,
+		@Param("eventId") UUID eventId
+	);
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/infrastructure/ProcessedEventRepositoryAdapter.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/infrastructure/ProcessedEventRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package com.node5.catalogservice.inventory.infrastructure;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.node5.catalogservice.inventory.domain.ProcessedEventRepository;
+import com.node5.catalogservice.inventory.domain.ProcessedEventType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProcessedEventRepositoryAdapter implements ProcessedEventRepository {
+
+	private final ProcessedEventJpaRepository processedEventJpaRepository;
+
+	@Override
+	@Transactional
+	public boolean tryInsert(ProcessedEventType type, UUID eventId) {
+		return processedEventJpaRepository.tryInsert(type.name(), eventId) == 1;
+	}
+}

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/infrastructure/kafka/KafkaStockRestoreEventConsumer.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/infrastructure/kafka/KafkaStockRestoreEventConsumer.java
@@ -1,0 +1,56 @@
+package com.node5.catalogservice.inventory.infrastructure.kafka;
+
+import java.util.List;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.node5.catalogservice.inventory.application.InventoryRestoreService;
+import com.node5.catalogservice.inventory.application.dto.StockRestoreBatchCommand;
+import com.node5.catalogservice.inventory.application.dto.StockRestoreItemCommand;
+import com.node5.common.event.StockRestoreEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaStockRestoreEventConsumer {
+
+	private final InventoryRestoreService inventoryRestoreService;
+
+	@KafkaListener(
+		topics = "${app.kafka.topics.stock-restore}",
+		groupId = "${spring.kafka.consumer.group-id:catalog-service-inventory}"
+	)
+	public void consume(StockRestoreEvent event) {
+
+		if (event == null || event.cancelEventId() == null || event.orderId() == null || event.items() == null) {
+			log.warn("재고 복원 이벤트가 null이거나 필수 값이 없습니다. event={}", event);
+			return;
+		}
+
+		log.info("Kafka 재고 복원 이벤트 수신, orderId={}, cancelEventId={}, itemsCount={}",
+			event.orderId(), event.cancelEventId(), event.items().size());
+
+		try {
+			StockRestoreBatchCommand command = toCommand(event);
+			inventoryRestoreService.restoreBatch(command);
+
+			log.info("재고 복원 처리 완료, orderId={}, cancelEventId={}", event.orderId(), event.cancelEventId());
+
+		} catch (Exception e) {
+			log.error("재고 복원 처리 실패, orderId={}, cancelEventId={}", event.orderId(), event.cancelEventId(), e);
+			throw e;
+		}
+	}
+
+	private StockRestoreBatchCommand toCommand(StockRestoreEvent event) {
+		List<StockRestoreItemCommand> items = event.items().stream()
+			.map(i -> new StockRestoreItemCommand(i.productId(), i.quantity()))
+			.toList();
+
+		return new StockRestoreBatchCommand(event.orderId(), event.cancelEventId(), items);
+	}
+}

--- a/common/src/main/java/com/node5/common/event/StockRestoreEvent.java
+++ b/common/src/main/java/com/node5/common/event/StockRestoreEvent.java
@@ -1,0 +1,13 @@
+package com.node5.common.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record StockRestoreEvent(
+	UUID cancelEventId,
+	UUID orderId,
+	List<Item> items
+) {
+	public record Item(UUID productId, int quantity) {
+	}
+}

--- a/config/config/catalog-service.yaml
+++ b/config/config/catalog-service.yaml
@@ -40,6 +40,7 @@ app:
       product-index: catalog-service.product-index.v1
       product-embedding: catalog-service.product-embedding.v1
       product-discontinued: catalog-service.product-discontinued.v1
+      stock-restore: order-service.stock-restore.v1
 
   s3:
     bucket: ${S3_BUCKET_NAME}

--- a/docs/ddl/catalog-ddl.sql
+++ b/docs/ddl/catalog-ddl.sql
@@ -74,6 +74,13 @@ CREATE TABLE catalog.product_idempotency (
     CONSTRAINT ck_product_idempotency_status CHECK (status IN ('PROCESSING', 'COMPLETED', 'FAILED'))
 );
 
+CREATE TABLE catalog.processed_event (
+    event_type VARCHAR(50) NOT NULL,
+    event_id uuid NOT NULL,
+    created_at timestamp(6) NOT NULL DEFAULT now(),
+    CONSTRAINT pk_processed_event PRIMARY KEY (event_type, event_id)
+);
+
 CREATE INDEX ix_stock_reservation_product_status
     ON catalog.stock_reservation (product_id, status);
 


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #564 

## 📌 개요
- 주문 완료 이후 환불(취소) 시 재고를 복원하기 위한 이벤트 기반 처리 로직을 추가합니다.

## ✨ 작업 내용
- 재고 복원을 위한 서비스 로직 추가
- Kafka 이벤트 수신 기반 재고 복원 처리

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
