### PR TITLE
fix: 정산 요청 대상 데이터 필터링 조건 추가

### DIFF
--- a/order-service/src/main/java/com/node5/orderservice/order/application/OrderTransactionService.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/application/OrderTransactionService.java
@@ -49,7 +49,11 @@ public class OrderTransactionService {
         log.info("구매 확정된 상품 정보를 정산 테이블에 적재 시도");
 
         // CONFIRMED 상태의 주문 상품 목록 조회
-        List<OrderItem> orderItems = orderItemRepository.findByStatus(OrderProgress.CONFIRMED);
+        List<OrderItem> orderItems = orderItemRepository.findByStatusAndSettlementStatus(OrderProgress.CONFIRMED, OrderItemSettlementStatus.PENDING);
+        if(orderItems.isEmpty()){
+            log.info("CONFIRMED 상태의 주문 상품이 없습니다. 정산 요청을 생략합니다.");
+            return;
+        }
 
         // Product ID로 Shop ID 조회 (catalog-client 연동)
         List<UUID> allProductIds = orderItems.stream()

--- a/order-service/src/main/java/com/node5/orderservice/order/domain/OrderItemRepository.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/domain/OrderItemRepository.java
@@ -23,7 +23,9 @@ public interface OrderItemRepository {
 
     Boolean existsInProgressByMemberId(UUID memberId, Collection<OrderProgress> doneStatus);
 
-    List<OrderItem> findByStatus(OrderProgress orderProgress);
+    List<OrderItem> findByStatus(OrderProgress status);
+
+    List<OrderItem> findByStatusAndSettlementStatus(OrderProgress status, OrderItemSettlementStatus settlementStatus);
 
     void updateSettlementStatus(List<UUID> orderItemIds, OrderItemSettlementStatus settlementStatus);
 

--- a/order-service/src/main/java/com/node5/orderservice/order/domain/OrderStatus.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/domain/OrderStatus.java
@@ -10,8 +10,6 @@ public enum OrderStatus {
     PAID("결제완료"),
     PAYMENT_FAILED("결제실패"),
     CANCELED("주문취소"),
-    REFUNDED("환불완료"),
-    SETTLEMENT_REQUESTED("정산준비")
     ;
 
     private final String name;

--- a/order-service/src/main/java/com/node5/orderservice/order/infrastructure/OrderItemJpaRepository.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/infrastructure/OrderItemJpaRepository.java
@@ -50,6 +50,8 @@ public interface OrderItemJpaRepository extends JpaRepository<OrderItem, UUID> {
 
     List<OrderItem> findByStatus(OrderProgress status);
 
+    List<OrderItem> findByStatusAndSettlementStatus(OrderProgress status, OrderItemSettlementStatus settlementStatus);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE OrderItem oi " +
             "SET oi.settlementStatus = :settlementStatus " +

--- a/order-service/src/main/java/com/node5/orderservice/order/infrastructure/OrderItemRepositoryAdapter.java
+++ b/order-service/src/main/java/com/node5/orderservice/order/infrastructure/OrderItemRepositoryAdapter.java
@@ -59,6 +59,11 @@ public class OrderItemRepositoryAdapter implements OrderItemRepository {
     }
 
     @Override
+    public List<OrderItem> findByStatusAndSettlementStatus(OrderProgress status, OrderItemSettlementStatus settlementStatus) {
+        return orderItemJpaRepository.findByStatusAndSettlementStatus(status, settlementStatus);
+    }
+
+    @Override
     public void updateSettlementStatus(List<UUID> orderItemIds, OrderItemSettlementStatus settlementStatus) {
         orderItemJpaRepository.updateSettlementStatus(orderItemIds, settlementStatus);
     }


### PR DESCRIPTION

## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #569 

## 📌 개요
- 구매 확정된 상품에 대해 정산 요청하는 로직을 수정합니다.

## ✨ 작업 내용
- 정산 요청 데이터 필터링 조건에 settlementStatus 추가
- 구매확정된 상품이 없을 경우 요청을 생략하도록 수정
- OrderStatus에서 환불 및 정산 요청 관련 상태 제거

## 🧪 테스트 방법
- 테스트한 방법을 작성해주세요.

## 🔗 참고 사항 : 
- 스크린샷, 참고 문서 등

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
