### PR TITLE
test: 재고 Hold/Release 동시성 및 멱등성 테스트 추가

### DIFF
--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/InventoryReservationService.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/application/InventoryReservationService.java
@@ -40,7 +40,6 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
 		}
 
-		// 1) productId 중복 합산 (입력 순서 유지)
 		Map<UUID, Integer> merged = new LinkedHashMap<>();
 		for (var item : command.items()) {
 			if (item == null || item.productId() == null || item.quantity() <= 0) {
@@ -49,7 +48,6 @@ public class InventoryReservationService {
 			merged.merge(item.productId(), item.quantity(), Integer::sum);
 		}
 
-		// 2) HOLD 진행 (성공한 것들만 기록)
 		var created = new ArrayList<StockReservationInfo>(merged.size());
 
 		try {
@@ -60,7 +58,6 @@ public class InventoryReservationService {
 			return StockHoldBatchResult.of(command.orderId(), created);
 
 		} catch (BaseException e) {
-			// 3) 하나라도 실패하면 지금까지 성공한 것들 전부 RELEASE로 보상
 			for (var info : created) {
 				try {
 					releaseInternal(new StockReleaseCommand(command.orderId(), info.productId()));
@@ -78,7 +75,6 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
 		}
 
-		// productId 중복 제거 (입력 순서 유지)
 		var unique = new LinkedHashSet<UUID>();
 		for (var item : command.items()) {
 			if (item == null || item.productId() == null) {
@@ -99,7 +95,6 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
 		}
 
-		// productId 중복 제거 (입력 순서 유지)
 		var unique = new LinkedHashSet<UUID>();
 		for (var item : command.items()) {
 			if (item == null || item.productId() == null) {
@@ -118,7 +113,6 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
 		}
 
-		// 1) 멱등: 기존 예약이 있으면 처리
 		var existingOpt = reservationRepository.findByOrderIdAndProductId(command.orderId(), command.productId());
 		if (existingOpt.isPresent()) {
 			StockReservation existing = existingOpt.get();
@@ -129,7 +123,6 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.RESERVATION_ALREADY_PROCESSED);
 		}
 
-		// 2) 조건부 차감
 		boolean decreased = stockRepository.decreaseIfEnough(command.productId(), command.quantity());
 		if (!decreased) {
 			if (!stockRepository.existsById(command.productId())) {
@@ -138,7 +131,6 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.OUT_OF_STOCK); // 409로 매핑
 		}
 
-		// 3) 예약 생성(HELD)
 		StockReservation reservation = StockReservation.held(
 			command.orderId(), command.productId(), command.quantity()
 		);
@@ -156,17 +148,14 @@ public class InventoryReservationService {
 			.findByOrderIdAndProductId(command.orderId(), command.productId())
 			.orElseThrow(() -> new BaseException(InventoryErrorCode.RESERVATION_NOT_FOUND));
 
-		// 1) 멱등: 이미 COMMITTED면 성공 처리
 		if (reservation.getStatus() == ReservationStatus.COMMITTED) {
 			return;
 		}
 
-		// 2) 정책: RELEASED면 commit 불가
 		if (reservation.getStatus() == ReservationStatus.RELEASED) {
 			throw new BaseException(InventoryErrorCode.RESERVATION_ALREADY_RELEASED);
 		}
 
-		// 3) HELD -> COMMITTED 조건부 전이
 		int updated = reservationRepository.updateStatus(
 			command.orderId(),
 			command.productId(),
@@ -195,22 +184,18 @@ public class InventoryReservationService {
 			throw new BaseException(InventoryErrorCode.INVALID_REQUEST);
 		}
 
-		// 1) 예약 조회
 		StockReservation reservation = reservationRepository
 			.findByOrderIdAndProductId(command.orderId(), command.productId())
 			.orElseThrow(() -> new BaseException(InventoryErrorCode.RESERVATION_NOT_FOUND));
 
-		// 2) 멱등: 이미 RELEASED면 성공 처리
 		if (reservation.getStatus() == ReservationStatus.RELEASED) {
 			return;
 		}
 
-		// 3) 정책: COMMITTED 상태는 해제 불가
 		if (reservation.getStatus() == ReservationStatus.COMMITTED) {
 			throw new BaseException(InventoryErrorCode.RESERVATION_ALREADY_COMMITTED);
 		}
 
-		// 4) HELD -> RELEASED 조건부 전이
 		int updated = reservationRepository.updateStatus(
 			command.orderId(),
 			command.productId(),
@@ -218,7 +203,6 @@ public class InventoryReservationService {
 			ReservationStatus.RELEASED
 		);
 
-		// 5) 상태 전이에 성공한 경우에만 재고 복구
 		if (updated == 1) {
 			int restored = stockRepository.increase(reservation.getProductId(), reservation.getQuantity());
 			if (restored == 0) {
@@ -227,7 +211,6 @@ public class InventoryReservationService {
 			return;
 		}
 
-		// 6) row=0이면 이미 다른 트랜잭션에서 상태가 바뀐 상태 → 최신 상태 확인
 		StockReservation latest = reservationRepository
 			.findByOrderIdAndProductId(command.orderId(), command.productId())
 			.orElseThrow(() -> new BaseException(InventoryErrorCode.RESERVATION_NOT_FOUND));

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/StockReservation.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/domain/StockReservation.java
@@ -47,8 +47,4 @@ public class StockReservation extends BaseEntity {
 	public static StockReservation held(UUID orderId, UUID productId, int quantity) {
 		return new StockReservation(UUID.randomUUID(), orderId, productId, quantity, ReservationStatus.HELD);
 	}
-
-	public boolean isHeld() {
-		return this.status == ReservationStatus.HELD;
-	}
 }

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/presentation/InventoryController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/presentation/InventoryController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("${api.v1}/stocks")
 @RequiredArgsConstructor
-@Tag(name = "Inventory", description = "상품 재고를 관리하는 API")
+@Tag(name = "Inventory", description = "상품 재고를 관리하는 관리용 API")
 public class InventoryController {
 
 	private final InventoryStockService inventoryStockService;

--- a/catalog-service/src/main/java/com/node5/catalogservice/inventory/presentation/InventoryInternalController.java
+++ b/catalog-service/src/main/java/com/node5/catalogservice/inventory/presentation/InventoryInternalController.java
@@ -13,61 +13,31 @@ import com.node5.catalogservice.inventory.presentation.dto.StockCommitBatchReque
 import com.node5.catalogservice.inventory.presentation.dto.StockHoldBatchRequest;
 import com.node5.catalogservice.inventory.presentation.dto.StockReleaseBatchRequest;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/internal/stocks/reservations")
 @RequiredArgsConstructor
-@Tag(name = "Inventory Internal", description = "주문/결제 흐름을 위한 내부 재고 예약 처리 API")
+@Hidden
 public class InventoryInternalController {
 
 	private final InventoryReservationService inventoryReservationService;
 
 	@PostMapping("/hold")
-	@Operation(
-		summary = "재고 선점",
-		description = "주문 생성 전에 재고를 임시로 차감하여 동시 구매로 인한 초과 판매를 방지합니다."
-	)
-	@ApiResponses({
-		@ApiResponse(responseCode = "201", description = "재고 선점 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않습니다."),
-		@ApiResponse(responseCode = "404", description = "상품 재고가 존재하지 않습니다.")
-	})
 	public ResponseEntity<StockHoldBatchResult> hold(@Valid @RequestBody StockHoldBatchRequest request) {
 		var result = inventoryReservationService.holdBatch(request.toCommand());
 		return ResponseEntity.status(HttpStatus.CREATED).body(result);
 	}
 
 	@PostMapping("/commit")
-	@Operation(
-		summary = "재고 확정",
-		description = "결제가 완료된 주문에 대해 선점된 재고를 확정 처리합니다."
-	)
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "재고 확정 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않습니다."),
-		@ApiResponse(responseCode = "404", description = "재고 예약이 존재하지 않습니다.")
-	})
 	public ResponseEntity<Void> commit(@Valid @RequestBody StockCommitBatchRequest request) {
 		inventoryReservationService.commitBatch(request.toCommand());
 		return ResponseEntity.ok().build();
 	}
 
 	@PostMapping("/release")
-	@Operation(
-		summary = "재고 해제",
-		description = "주문 실패 또는 취소 시 선점된 재고를 복구합니다."
-	)
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "재고 해제 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않습니다."),
-		@ApiResponse(responseCode = "404", description = "재고 예약이 존재하지 않습니다.")
-	})
 	public ResponseEntity<Void> release(@Valid @RequestBody StockReleaseBatchRequest request) {
 		inventoryReservationService.releaseBatch(request.toCommand());
 		return ResponseEntity.ok().build();

--- a/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryHoldConcurrencyTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryHoldConcurrencyTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,6 +19,7 @@ import com.node5.catalogservice.inventory.domain.Stock;
 import com.node5.catalogservice.inventory.infrastructure.StockJpaRepository;
 import com.node5.common.exception.BaseException;
 
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 @SpringBootTest
 @ActiveProfiles("test")
 public class InventoryHoldConcurrencyTest {

--- a/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryHoldConcurrencyTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryHoldConcurrencyTest.java
@@ -1,0 +1,62 @@
+package com.node5.catalogservice.inventory.concurrency;
+
+import static com.node5.catalogservice.testsupport.ConcurrentTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.node5.catalogservice.inventory.application.InventoryReservationService;
+import com.node5.catalogservice.inventory.application.dto.StockHoldBatchCommand;
+import com.node5.catalogservice.inventory.domain.Stock;
+import com.node5.catalogservice.inventory.infrastructure.StockJpaRepository;
+import com.node5.common.exception.BaseException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class InventoryHoldConcurrencyTest {
+
+	@Autowired
+	InventoryReservationService reservationService;
+
+	@Autowired
+	StockJpaRepository stockJpaRepository;
+
+	@Test
+	void 재고가_50일때_100명이_동시에_hold하면_성공50_실패50_최종0이다() throws Exception {
+		// given
+		UUID productId = UUID.randomUUID();
+		stockJpaRepository.save(Stock.create(productId, 50));
+
+		int threads = 100;
+		AtomicInteger success = new AtomicInteger();
+		AtomicInteger fail = new AtomicInteger();
+
+		// when
+		동시실행(threads, () -> {
+			UUID orderId = UUID.randomUUID();
+			try {
+				reservationService.holdBatch(
+					new StockHoldBatchCommand(
+						orderId, List.of(new StockHoldBatchCommand.Item(productId, 1))
+					)
+				);
+				success.incrementAndGet();
+			} catch (BaseException e) {
+				fail.incrementAndGet();
+			}
+		});
+
+		// then
+		int finalQty = stockJpaRepository.findById(productId).orElseThrow().getQuantity();
+		assertEquals(50, success.get());
+		assertEquals(50, fail.get());
+		assertEquals(0, finalQty);
+	}
+}

--- a/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryReleaseConcurrencyTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryReleaseConcurrencyTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -19,6 +20,7 @@ import com.node5.catalogservice.inventory.domain.Stock;
 import com.node5.catalogservice.inventory.infrastructure.StockJpaRepository;
 import com.node5.common.exception.BaseException;
 
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 @SpringBootTest
 @ActiveProfiles("test")
 public class InventoryReleaseConcurrencyTest {

--- a/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryReleaseConcurrencyTest.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/inventory/concurrency/InventoryReleaseConcurrencyTest.java
@@ -1,0 +1,148 @@
+package com.node5.catalogservice.inventory.concurrency;
+
+import static com.node5.catalogservice.testsupport.ConcurrentTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.node5.catalogservice.inventory.application.InventoryReservationService;
+import com.node5.catalogservice.inventory.application.dto.StockHoldBatchCommand;
+import com.node5.catalogservice.inventory.application.dto.StockReleaseBatchCommand;
+import com.node5.catalogservice.inventory.domain.Stock;
+import com.node5.catalogservice.inventory.infrastructure.StockJpaRepository;
+import com.node5.common.exception.BaseException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class InventoryReleaseConcurrencyTest {
+
+	@Autowired
+	InventoryReservationService reservationService;
+
+	@Autowired
+	StockJpaRepository stockJpaRepository;
+
+	@Test
+	void 같은_orderId로_release를_100번_동시에_요청해도_재고는_1번만_복구된다() throws Exception {
+		//given
+		UUID productId = UUID.randomUUID();
+		stockJpaRepository.save(Stock.create(productId, 50));
+
+		UUID orderId = UUID.randomUUID();
+		reservationService.holdBatch(
+			new StockHoldBatchCommand(
+				orderId, List.of(new StockHoldBatchCommand.Item(productId, 1))
+			)
+		);
+
+		assertEquals(49, stockJpaRepository.findById(productId).orElseThrow().getQuantity());
+
+		int threads = 100;
+		AtomicInteger success = new AtomicInteger();
+		AtomicInteger fail = new AtomicInteger();
+
+		// when
+		동시실행(threads, () -> {
+			try {
+				reservationService.releaseBatch(
+					new StockReleaseBatchCommand(
+						orderId, List.of(new StockReleaseBatchCommand.Item(productId))
+					)
+				);
+				success.incrementAndGet();
+			} catch (BaseException e) {
+				fail.incrementAndGet();
+			}
+		});
+
+		// then
+		int finalQty = stockJpaRepository.findById(productId).orElseThrow().getQuantity();
+
+		assertEquals(50, finalQty);
+		assertEquals(threads, success.get());
+		assertEquals(0, fail.get());
+	}
+
+	@Test
+	void hold와_release가_동시에_섞여_발생해도_재고정합성이_유지된다() throws Exception {
+		// given
+		UUID productId = UUID.randomUUID();
+		stockJpaRepository.save(Stock.create(productId, 50));
+
+		int n = 50;
+		UUID[] preHeldOrders = new UUID[n];
+		for (int i = 0; i < n; i++) {
+			UUID orderId = UUID.randomUUID();
+			preHeldOrders[i] = orderId;
+			reservationService.holdBatch(
+				new StockHoldBatchCommand(
+					orderId, List.of(new StockHoldBatchCommand.Item(productId, 1))
+				)
+			);
+		}
+
+		assertEquals(0, stockJpaRepository.findById(productId).orElseThrow().getQuantity());
+
+		AtomicInteger holdSuccess = new AtomicInteger();
+		AtomicInteger releaseSuccess = new AtomicInteger();
+		AtomicInteger releaseFail = new AtomicInteger();
+
+		// when
+		동시실행(
+			() -> {
+				for (int i = 0; i < n; i++) {
+					UUID orderId = preHeldOrders[i];
+					try {
+						reservationService.releaseBatch(
+							new StockReleaseBatchCommand(
+								orderId, List.of(new StockReleaseBatchCommand.Item(productId))
+							)
+						);
+						releaseSuccess.incrementAndGet();
+					} catch (BaseException e) {
+						releaseFail.incrementAndGet();
+					}
+				}
+			},
+			() -> {
+				for (int i = 0; i < n; i++) {
+					UUID newOrderId = UUID.randomUUID();
+
+					boolean done = false;
+					int attempts = 0;
+
+					while (!done && attempts++ < 2000) {
+						try {
+							reservationService.holdBatch(
+								new StockHoldBatchCommand(
+									newOrderId, List.of(new StockHoldBatchCommand.Item(productId, 1))
+								)
+							);
+							holdSuccess.incrementAndGet();
+							done = true;
+						} catch (BaseException e) {
+							try { Thread.sleep(2); } catch (InterruptedException ignored) {}
+						}
+					}
+
+					assertTrue(done, "hold의 재시도 횟수가 초과되었습니다.");
+				}
+			}
+		);
+
+		// then
+		int finalQty = stockJpaRepository.findById(productId).orElseThrow().getQuantity();
+
+		assertEquals(0, finalQty);
+
+		assertEquals(50, holdSuccess.get());
+		assertTrue(releaseSuccess.get() >= 1, "realeas는 최소 1회 성공해야 한다.");
+	}
+}

--- a/catalog-service/src/test/java/com/node5/catalogservice/testsupport/ConcurrentTestSupport.java
+++ b/catalog-service/src/test/java/com/node5/catalogservice/testsupport/ConcurrentTestSupport.java
@@ -1,0 +1,93 @@
+package com.node5.catalogservice.testsupport;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ConcurrentTestSupport {
+
+	private ConcurrentTestSupport() {
+	}
+
+	@FunctionalInterface
+	public interface ThrowingRunnable {
+		void run() throws Exception;
+	}
+
+	/**
+	 * 같은 작업(task)을 threads 개수만큼 동시에 실행
+	 * 예) 동시실행(100, () -> hold())
+	 */
+	public static void 동시실행(int threads, ThrowingRunnable task) throws Exception {
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		CountDownLatch ready = new CountDownLatch(threads);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threads);
+
+		AtomicReference<Throwable> firstError = new AtomicReference<>(null);
+
+		for (int i = 0; i < threads; i++) {
+			pool.submit(() -> {
+				ready.countDown();
+				try {
+					start.await();
+					task.run();
+				} catch (Throwable e) {
+					firstError.compareAndSet(null, e);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+		pool.shutdown();
+
+		Throwable error = firstError.get();
+		if (error != null) {
+			throw new AssertionError("동시 실행 작업 중 예외가 발생했습니다.", error);
+		}
+	}
+
+	/**
+	 * 서로 다른 작업들을 각각 1개 스레드로 동시에 실행
+	 * 예) 동시실행(() -> release반복(), () -> hold반복())
+	 */
+	public static void 동시실행(ThrowingRunnable... tasks) throws Exception {
+		int threads = tasks.length;
+
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		CountDownLatch ready = new CountDownLatch(threads);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threads);
+
+		AtomicReference<Throwable> firstError = new AtomicReference<>(null);
+
+		for (ThrowingRunnable task : tasks) {
+			pool.submit(() -> {
+				ready.countDown();
+				try {
+					start.await();
+					task.run();
+				} catch (Throwable e) {
+					firstError.compareAndSet(null, e);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+		pool.shutdown();
+
+		Throwable error = firstError.get();
+		if (error != null) {
+			throw new AssertionError("동시 실행 작업 중 예외가 발생했습니다.", error);
+		}
+	}
+}

--- a/catalog-service/src/test/resources/application-test.yaml
+++ b/catalog-service/src/test/resources/application-test.yaml
@@ -1,31 +1,43 @@
 spring:
-  cloud:
-    config:
-      enabled: false
-      fail-fast: false
-  config:
-    import: ""
-
   datasource:
-    url: jdbc:h2:mem:catalog-test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:postgresql://localhost:5432/catalog_test?currentSchema=catalog
+    username: postgres
+    password: postgres
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: catalog
+
+  sql:
+    init:
+      mode: always
+
+  kafka:
+    listener:
+      auto-startup: false
+
 
 api:
   v1: /api/v1
 
 apigateway:
-  host: http://localhost:8000
+  host: http://test
+
 
 app:
-  search:
-    index:
-      product: test_products
+  kafka:
+    topics:
+      member-deleted: member-service.member-deleted.v1
+      shop-deleted: member-service.shop-deleted.v1
+      product-index: catalog-service.product-index.v1
+      product-embedding: catalog-service.product-embedding.v1
+      product-discontinued: catalog-service.product-discontinued.v1
+      stock-restore: order-service.stock-restore.v1
+
+  s3:
+    region: ap-northeast-2
+    bucket: test-bucket

--- a/catalog-service/src/test/resources/schema.sql
+++ b/catalog-service/src/test/resources/schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS catalog;


### PR DESCRIPTION
## 관련 이슈
 <!-- Close #{이슈-번호} 형태로 작성하세요 (ex: Close #134) -->
close #571 

## 📌 개요
- 재고 선점(Hold) 및 복구(Release) 로직의 동시성/멱등성 보장을 검증하는 테스트를 추가합니다.

## ✨ 작업 내용
- 다수의 주문 요청이 동시에 발생하는 상황에서 배고 초과 차감(oversell)이 발생하지 않음을 검증합니다
- 동일 주문에 대한 중복 Release 요청이 발생해도 재고가 한 번만 복구되는 멱등성을 보장함을 검증합니다
- 주문 성공/취소가 동시에 발생하는 레이스 컨디션 상황에서도 재고 정합성이 유지되는지를 테스트합니다

## 🧪 테스트 방법

## 🔗 참고 사항 : 

## 체크리스트
 <!-- 마지막으로 PR을 만들기 전에 확인해야 할 목록입니다.-->
- [ ] 오류가 발생하지 않습니다.
- [ ] 테스트를 전부 통과했습니다.
- [ ] 이 프로젝트의 코드 컨벤션을 준수했습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
- [ ] 이슈 번호를 입력 했습니다.
- [ ] 리뷰어를 설정했습니다.


## 검토자 체크리스트
- [ ] 요청을 받은 후 하루 이내에 피드백을 보냈습니다.
- [ ] 본인이 검토해야하는 PR 피드백을 남겼습니다.
- [ ] 해당 브랜치가 develop에 merge 요청을 보냈습니다.
